### PR TITLE
SERVER-HEADWAY-003: Implement learning questions backend and gateway GraphQL with guest sessions

### DIFF
--- a/.cursor/memory-bank/activeContext.md
+++ b/.cursor/memory-bank/activeContext.md
@@ -2,14 +2,14 @@
 
 ## Current branch intent
 
-- `chore/spec-kit-memory-bank` — integrate **GitHub Spec Kit** (Specify 0.4.0) and a **Memory Bank** under `.cursor/memory-bank/`, without changing application or CI code.
+- `003-learning-questions-server` — deliver **spec 003** learning-questions flow: database service (catalog, progress, remarks, guest sessions), gateway GraphQL + auth policy, JWT guest integration, and related API contracts.
 
 ## Immediate next steps (for the human)
 
-- Review `.gitignore` change (`.cursor/projects/` only; `.cursor/commands/` and `.cursor/memory-bank/` are tracked).
-- Skim [docs/ai-workflow.md](../../docs/ai-workflow.md) and run a Spec Kit command when starting the next spec (e.g. `/speckit.constitution` or `/speckit.specify`).
-- After merge: delete stale local-only paths under `.cursor/` if your machine still has old ignored clutter.
+- Open or refresh the PR against `trunk`; run CI if required beyond local `./gradlew build` / `detekt`.
+- Apply DB migration `server/database/migrations/V001_learning_questions.sql` in the target Postgres environment when deploying.
+- Align GitHub issue number with `Closes #…` in the PR if it is not **#3**.
 
 ## Notes
 
-- `specify init --offline` avoids GitHub API rate limits; use `GH_TOKEN` if you need online template refresh later.
+- Agent rules: `.cursor/rules/` + closest `AGENTS.md`; cumulative lessons in `lessons-learned.mdc` (now includes §18 serialization, §19 `data/` layout vs `repository/`).

--- a/.cursor/memory-bank/progress.md
+++ b/.cursor/memory-bank/progress.md
@@ -2,6 +2,11 @@
 
 Changelog for **AI workflow** and **Memory Bank** maintenance (not product release notes).
 
+## 2026-03-27
+
+- **Server (spec 003):** learning-questions HTTP + GraphQL surface (database internal + gateway), guest session register/revoke/validate, preparation→learning progress sync; `@SerialName` coverage on affected wire models and Ktor resources; non-repository persistence helpers moved to `data/scope` and `data/learning`.
+- **Cursor:** `lessons-learned.mdc` §18–§19; `systemPatterns.md` updated for serialization and `data/` layout.
+
 ## 2026-03-24
 
 - Added GitHub **Spec Kit** artifacts: `.specify/` (templates, memory constitution scaffold, bash + PowerShell scripts), `.cursor/commands/speckit.*.md`.

--- a/.cursor/memory-bank/systemPatterns.md
+++ b/.cursor/memory-bank/systemPatterns.md
@@ -8,6 +8,8 @@ Patterns called out in `AGENTS.md` / `client/AGENTS.md` / `server/AGENTS.md` and
 - **Client errors:** model expected failures with **`Outcome`**, not ad-hoc exceptions for domain cases.
 - **Client navigation:** use **`NavigatorContract`** / `NavigationIntent`, not ad-hoc platform navigation.
 - **Server gateways:** wrap outbound HTTP in **`upstreamCall`** with consistent dependency error mapping.
+- **Server serialization:** every `@Serializable` property uses `@SerialName` with the real wire key; when annotating existing types, match the current JSON/query names (see `.cursor/rules/lessons-learned.mdc` §18).
+- **Server `data` layout:** `data/repository` holds only repository implementations; scope queries, sync helpers, and similar live under sibling `data/<role>/` packages (see lessons-learned §19).
 - **Gateway health:** `CheckHealthStatusUseCase` probes each downstream service’s **`/healthz`** (under that service’s base URL) via `BaseHttpProbe`; add a probe for every Koin-tagged `HttpClient` the gateway uses for microservices (auth, database, home, …).
 - **Lessons:** cumulative anti-patterns live in `.cursor/rules/lessons-learned.mdc` (curated, not a dump of every chat).
 

--- a/.cursor/rules/lessons-learned.mdc
+++ b/.cursor/rules/lessons-learned.mdc
@@ -164,3 +164,21 @@ alwaysApply: true
 - **Why it exists:** [server/AGENTS.md](../../server/AGENTS.md) documents gateway dependency probes via `HealthzResource`; skipping a wired service hides outages from operators and from the public health contract.
 - **Bad pattern (short):** `createServiceHttpClient<HomeKoinHttpClient>(…)` and `HomeRepository` calls exist, but health aggregation only checks auth and database.
 - **Correct pattern (short):** `HomeServiceProbe(httpClient)` plus `GatewayDependencyHealth(name = "home", …)` and include its status when computing overall `GatewayServiceStatus`.
+
+---
+
+### 18
+
+- **Rule:** On the server, every serializable **property** on `@Serializable` types (DTOs, gateway GraphQL models, nested Ktor `@Resource` parameter classes, enums) must be annotated with `@SerialName("…")` using the **actual wire key** (query/path/JSON) for that type.
+- **Why it exists:** Explicit keys document the contract and prevent silent renames when Kotlin property names change; mixed annotated/unannotated fields are easy to miss in review and drift from inter-service expectations.
+- **Bad pattern (short):** `@Serializable data class X( @SerialName("a") val a: String, val b: String )` or omitting `@SerialName` on Ktor resource `parent` / path parameters while other fields use snake_case query keys.
+- **Correct pattern (short):** Annotate **each** constructor property (including `parent` on resources and UUID/custom-serialized fields); when formalizing legacy DTOs, set `@SerialName` to match the **previous** implicit kotlinx name (often camelCase) or the established snake_case API—never rename keys in the same edit unless intentionally versioning the contract.
+
+---
+
+### 19
+
+- **Rule:** In `*/internal/data`, keep **`repository/`** for types that implement a **`…RepositoryContract`** (or are clearly named `*Repository` HTTP/DB facades). Put other persistence helpers—Exposed query/scoping functions, cross-domain sync writers, one-off SQL utilities—in a **sibling subpackage** under `data/` (e.g. `data/scope`, `data/learning`), not beside repositories in the same directory.
+- **Why it exists:** [server/AGENTS.md](../../server/AGENTS.md) maps `data/repository` to repository implementations; mixing non-repositories there blurs the port/adapter boundary and makes discovery harder.
+- **Bad pattern (short):** `LearningQuestionPreparationSync` or `FacilitatorSubjectScopeQueries.kt` (top-level scope checks) living under `data/repository/` next to `UsersRepository`.
+- **Correct pattern (short):** `data/learning/LearningQuestionPreparationSync.kt`, `data/scope/FacilitatorSubjectScope.kt` (or another purposeful name); repositories stay in `data/repository/` and import those helpers.

--- a/.cursor/rules/specify-rules.mdc
+++ b/.cursor/rules/specify-rules.mdc
@@ -6,11 +6,12 @@ alwaysApply: true
 
 # Headway Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-03-26
+Auto-generated from all feature plans. Last updated: 2026-03-27
 
 ## Active Technologies
 - Kotlin 2.x, JVM 17 + Ktor + Netty; KGraphQL (gateway); Koin; kotlinx.serialization; Exposed (database service) (002-training-session-backend)
 - PostgreSQL (hosted Supabase in env templates); preparation session tables: sessions, outcomes, catalog, mentorships, preparation plan (`specs/002-training-session-backend/data-model.md`) (002-training-session-backend)
+- PostgreSQL (hosted Supabase); existing question catalog tables + new tables for progress, remarks, guest revocation (003-learning-questions-server)
 
 - Python 3 (stdlib only for validation and merge) + None beyond Python stdlib; Supabase/Postgres on the operator side (001-interview-questions-supabase)
 
@@ -30,6 +31,7 @@ cd src [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLO
 Python 3 (stdlib only for validation and merge): Follow standard conventions
 
 ## Recent Changes
+- 003-learning-questions-server: Added Kotlin 2.x, JVM 17 + Ktor + Netty; KGraphQL (gateway); Koin; kotlinx.serialization; Exposed (database service)
 - 002-training-session-backend: Added Kotlin 2.x, JVM 17 + Ktor + Netty; KGraphQL (gateway); Koin; kotlinx.serialization; Exposed (database service)
 
 - 001-interview-questions-supabase: Added Python 3 (stdlib only for validation and merge) + None beyond Python stdlib; Supabase/Postgres on the operator side

--- a/server/admin/api/src/main/kotlin/dev/kigya/headway/admin/api/model/resource/AdminResource.kt
+++ b/server/admin/api/src/main/kotlin/dev/kigya/headway/admin/api/model/resource/AdminResource.kt
@@ -1,6 +1,7 @@
 package dev.kigya.headway.admin.api.model.resource
 
 import io.ktor.resources.Resource
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -8,36 +9,38 @@ import kotlinx.serialization.Serializable
 class AdminResource {
     @Serializable
     @Resource("app")
-    data class App(val parent: AdminResource = AdminResource())
+    data class App(@SerialName("parent") val parent: AdminResource = AdminResource())
 
     @Serializable
     @Resource("bootstrap")
-    data class Bootstrap(val parent: AdminResource = AdminResource())
+    data class Bootstrap(@SerialName("parent") val parent: AdminResource = AdminResource())
 
     @Serializable
     @Resource("invite")
-    data class Invite(val parent: AdminResource = AdminResource())
+    data class Invite(@SerialName("parent") val parent: AdminResource = AdminResource())
 
     @Serializable
     @Resource("logout")
-    data class Logout(val parent: AdminResource = AdminResource())
+    data class Logout(@SerialName("parent") val parent: AdminResource = AdminResource())
 
     @Serializable
     @Resource("assets/{name}")
     data class Asset(
+        @SerialName("parent")
         val parent: AdminResource = AdminResource(),
+        @SerialName("name")
         val name: String,
     )
 
     @Serializable
     @Resource("auth")
-    data class Auth(val parent: AdminResource = AdminResource()) {
+    data class Auth(@SerialName("parent") val parent: AdminResource = AdminResource()) {
         @Serializable
         @Resource("github")
-        data class Github(val parent: Auth = Auth())
+        data class Github(@SerialName("parent") val parent: Auth = Auth())
 
         @Serializable
         @Resource("github/callback")
-        data class GithubCallback(val parent: Auth = Auth())
+        data class GithubCallback(@SerialName("parent") val parent: Auth = Auth())
     }
 }

--- a/server/admin/internal/src/main/kotlin/dev/kigya/headway/admin/internal/core/session/AdminSession.kt
+++ b/server/admin/internal/src/main/kotlin/dev/kigya/headway/admin/internal/core/session/AdminSession.kt
@@ -1,5 +1,6 @@
 package dev.kigya.headway.admin.internal.core.session
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.security.MessageDigest
@@ -9,9 +10,13 @@ import javax.crypto.spec.SecretKeySpec
 
 @Serializable
 internal data class AdminSession(
+    @SerialName("githubLogin")
     val githubLogin: String,
+    @SerialName("githubAvatarUrl")
     val githubAvatarUrl: String? = null,
+    @SerialName("hasRepositoryAccess")
     val hasRepositoryAccess: Boolean,
+    @SerialName("createdAt")
     val createdAt: Long,
 ) {
     companion object {

--- a/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/data/jwt/JWTRepository.kt
+++ b/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/data/jwt/JWTRepository.kt
@@ -4,6 +4,7 @@ import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.exceptions.JWTDecodeException
 import com.auth0.jwt.exceptions.TokenExpiredException
+import dev.kigya.headway.auth.internal.domain.repository.GeneratedGuestAccessToken
 import dev.kigya.headway.auth.internal.domain.repository.GuestAccessTokenPayload
 import dev.kigya.headway.auth.internal.domain.repository.JWTRepositoryContract
 import java.time.Clock
@@ -50,7 +51,7 @@ internal class JWTRepository(
             .sign(refreshAlgorithm)
     }
 
-    override fun generateGuestAccessToken(): Pair<String, Long> {
+    override fun generateGuestAccessToken(): GeneratedGuestAccessToken {
         val sessionId = UUID.randomUUID()
         val now = Instant.now(clock)
         val expiresAt = now.plusSeconds(config.guestTtlSec)
@@ -64,7 +65,11 @@ internal class JWTRepository(
             .withIssuedAt(Date.from(now))
             .withExpiresAt(Date.from(expiresAt))
             .sign(guestAlgorithm)
-        return token to expiresAt.toEpochMilli()
+        return GeneratedGuestAccessToken(
+            accessToken = token,
+            expiresAtEpochMs = expiresAt.toEpochMilli(),
+            sessionId = sessionId,
+        )
     }
 
     override fun isAccessTokenValid(token: String): Boolean = try {

--- a/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/data/repository/DatabaseRepository.kt
+++ b/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/data/repository/DatabaseRepository.kt
@@ -3,6 +3,7 @@ package dev.kigya.headway.auth.internal.data.repository
 import dev.kigya.headway.auth.internal.domain.error.AuthException
 import dev.kigya.headway.auth.internal.domain.repository.DatabaseRepositoryContract
 import dev.kigya.headway.database.api.model.`in`.DatabaseCreateSessionPayloadDto
+import dev.kigya.headway.database.api.model.`in`.DatabaseGuestSessionRegisterRequestDto
 import dev.kigya.headway.database.api.model.`in`.DatabaseSessionPlatform
 import dev.kigya.headway.database.api.model.`in`.DatabaseUpsertGoogleUserPayloadDto
 import dev.kigya.headway.database.api.model.`in`.DatabaseValidateSessionPayloadDto
@@ -10,6 +11,7 @@ import dev.kigya.headway.database.api.model.out.DatabaseUser
 import dev.kigya.headway.database.api.model.resource.DatabaseResource
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.plugins.resources.get
 import io.ktor.client.plugins.resources.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -116,6 +118,49 @@ class DatabaseRepository(
             HttpStatusCode.NotFound,
             HttpStatusCode.Forbidden,
             -> throw AuthException.Unauthorized("Invalid session")
+
+            else -> throw AuthException.UpstreamProtocol(
+                dependency = DATABASE_DEPENDENCY_NAME,
+                status = status.value,
+            )
+        }
+    }
+
+    override suspend fun registerGuestSession(sessionId: UUID) {
+        val response = try {
+            httpClient.post(DatabaseResource.GuestSessions.Register()) {
+                contentType(ContentType.Application.Json)
+                setBody(DatabaseGuestSessionRegisterRequestDto(id = sessionId))
+            }
+        } catch (t: Throwable) {
+            throw AuthException.DependencyUnavailable(DATABASE_DEPENDENCY_NAME, cause = t)
+        }
+
+        when (val status = response.status) {
+            HttpStatusCode.Created -> return
+            else -> throw AuthException.UpstreamProtocol(
+                dependency = DATABASE_DEPENDENCY_NAME,
+                status = status.value,
+            )
+        }
+    }
+
+    override suspend fun ensureGuestSessionActive(sessionId: UUID) {
+        val response = try {
+            httpClient.get(
+                DatabaseResource.GuestSessions.Validate(
+                    sessionId = sessionId,
+                ),
+            )
+        } catch (t: Throwable) {
+            throw AuthException.DependencyUnavailable(DATABASE_DEPENDENCY_NAME, cause = t)
+        }
+
+        when (val status = response.status) {
+            HttpStatusCode.OK -> return
+            HttpStatusCode.Forbidden,
+            HttpStatusCode.NotFound,
+            -> throw AuthException.Unauthorized("Guest session is not active")
 
             else -> throw AuthException.UpstreamProtocol(
                 dependency = DATABASE_DEPENDENCY_NAME,

--- a/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/domain/repository/DatabaseRepositoryContract.kt
+++ b/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/domain/repository/DatabaseRepositoryContract.kt
@@ -25,4 +25,8 @@ internal interface DatabaseRepositoryContract {
         refreshToken: String,
         fingerprint: String,
     )
+
+    suspend fun registerGuestSession(sessionId: UUID)
+
+    suspend fun ensureGuestSessionActive(sessionId: UUID)
 }

--- a/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/domain/repository/JWTRepositoryContract.kt
+++ b/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/domain/repository/JWTRepositoryContract.kt
@@ -3,6 +3,12 @@ package dev.kigya.headway.auth.internal.domain.repository
 import java.util.Date
 import java.util.UUID
 
+internal data class GeneratedGuestAccessToken(
+    val accessToken: String,
+    val expiresAtEpochMs: Long,
+    val sessionId: UUID,
+)
+
 internal interface JWTRepositoryContract {
 
     fun generateAccessToken(userUUID: UUID): String
@@ -12,7 +18,7 @@ internal interface JWTRepositoryContract {
         expirationDate: Date,
     ): String
 
-    fun generateGuestAccessToken(): Pair<String, Long>
+    fun generateGuestAccessToken(): GeneratedGuestAccessToken
 
     fun isAccessTokenValid(token: String): Boolean
 

--- a/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/domain/usecase/LoginAsGuestUseCase.kt
+++ b/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/domain/usecase/LoginAsGuestUseCase.kt
@@ -1,16 +1,19 @@
 package dev.kigya.headway.auth.internal.domain.usecase
 
 import dev.kigya.headway.auth.api.model.out.AuthGuestLoginResponse
+import dev.kigya.headway.auth.internal.domain.repository.DatabaseRepositoryContract
 import dev.kigya.headway.auth.internal.domain.repository.JWTRepositoryContract
 
 internal class LoginAsGuestUseCase(
     private val jwtRepository: JWTRepositoryContract,
+    private val databaseRepository: DatabaseRepositoryContract,
 ) {
-    operator fun invoke(): AuthGuestLoginResponse {
-        val (token, expiresAtEpochMs) = jwtRepository.generateGuestAccessToken()
+    suspend operator fun invoke(): AuthGuestLoginResponse {
+        val issued = jwtRepository.generateGuestAccessToken()
+        databaseRepository.registerGuestSession(sessionId = issued.sessionId)
         return AuthGuestLoginResponse(
-            accessToken = token,
-            expiresAtEpochMs = expiresAtEpochMs,
+            accessToken = issued.accessToken,
+            expiresAtEpochMs = issued.expiresAtEpochMs,
         )
     }
 }

--- a/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/domain/usecase/ValidateAccessTokenUseCase.kt
+++ b/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/domain/usecase/ValidateAccessTokenUseCase.kt
@@ -4,12 +4,14 @@ import dev.kigya.headway.auth.api.AuthServicePlainText
 import dev.kigya.headway.auth.api.model.out.AuthPrincipalType
 import dev.kigya.headway.auth.api.model.out.AuthValidateTokenResponse
 import dev.kigya.headway.auth.internal.domain.error.AuthException
+import dev.kigya.headway.auth.internal.domain.repository.DatabaseRepositoryContract
 import dev.kigya.headway.auth.internal.domain.repository.JWTRepositoryContract
 
 internal class ValidateAccessTokenUseCase(
     private val jwtRepository: JWTRepositoryContract,
+    private val databaseRepository: DatabaseRepositoryContract,
 ) {
-    operator fun invoke(accessToken: String): AuthValidateTokenResponse {
+    suspend operator fun invoke(accessToken: String): AuthValidateTokenResponse {
         val trimmedToken = accessToken.trim()
         if (trimmedToken.isBlank()) {
             throw AuthException.Unauthorized(AuthServicePlainText.INVALID_ACCESS_TOKEN)
@@ -17,7 +19,7 @@ internal class ValidateAccessTokenUseCase(
         if (jwtRepository.isAccessTokenValid(trimmedToken)) {
             return userPrincipal(trimmedToken)
         }
-        return guestOrReject(trimmedToken)
+        return guestOrReject(token = trimmedToken)
     }
 
     private fun userPrincipal(token: String): AuthValidateTokenResponse {
@@ -29,10 +31,10 @@ internal class ValidateAccessTokenUseCase(
         )
     }
 
-    private fun guestOrReject(token: String): AuthValidateTokenResponse {
+    private suspend fun guestOrReject(token: String): AuthValidateTokenResponse {
         val tokenType = jwtRepository.decodeTokenType(token)
         if (tokenType == TOKEN_TYPE_GUEST_ACCESS) {
-            return guestPrincipal(token)
+            return guestPrincipal(token = token)
         }
         if (tokenType == TOKEN_TYPE_ACCESS && jwtRepository.isUserAccessTokenExpiredByClaims(token)) {
             throw AuthException.Unauthorized(AuthServicePlainText.ACCESS_TOKEN_EXPIRED)
@@ -40,12 +42,13 @@ internal class ValidateAccessTokenUseCase(
         throw AuthException.Unauthorized(AuthServicePlainText.INVALID_ACCESS_TOKEN)
     }
 
-    private fun guestPrincipal(token: String): AuthValidateTokenResponse {
+    private suspend fun guestPrincipal(token: String): AuthValidateTokenResponse {
         if (jwtRepository.isGuestAccessTokenExpiredByClaims(token)) {
             throw AuthException.Unauthorized(AuthServicePlainText.GUEST_TOKEN_EXPIRED)
         }
         val guestPayload = jwtRepository.validateGuestAccessToken(token)
             ?: throw AuthException.Unauthorized(AuthServicePlainText.INVALID_GUEST_TOKEN)
+        databaseRepository.ensureGuestSessionActive(sessionId = guestPayload.sessionId)
         return AuthValidateTokenResponse(
             principalType = AuthPrincipalType.GUEST,
             guestSessionId = guestPayload.sessionId,

--- a/server/auth/internal/src/test/kotlin/dev/kigya/headway/auth/internal/data/jwt/JWTRepositoryTest.kt
+++ b/server/auth/internal/src/test/kotlin/dev/kigya/headway/auth/internal/data/jwt/JWTRepositoryTest.kt
@@ -28,8 +28,9 @@ class JWTRepositoryTest {
     fun `guest token validates and carries session and scope`() {
         val clock = Clock.systemUTC()
         val jwt: JWTRepositoryContract = JWTRepository(config = config, clock = clock)
-        val (token, expMs) = jwt.generateGuestAccessToken()
-        assertTrue(expMs > clock.instant().toEpochMilli())
+        val issued = jwt.generateGuestAccessToken()
+        val token = issued.accessToken
+        assertTrue(issued.expiresAtEpochMs > clock.instant().toEpochMilli())
 
         val payload = jwt.validateGuestAccessToken(token)
         assertNotNull(payload)
@@ -52,7 +53,7 @@ class JWTRepositoryTest {
     fun `guest token is not valid as user access`() {
         val clock = Clock.systemUTC()
         val jwt: JWTRepositoryContract = JWTRepository(config = config, clock = clock)
-        val (guestToken, _) = jwt.generateGuestAccessToken()
+        val guestToken = jwt.generateGuestAccessToken().accessToken
         assertFalse(jwt.isAccessTokenValid(guestToken))
     }
 

--- a/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/in/DatabaseGuestSessionRegisterRequestDto.kt
+++ b/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/in/DatabaseGuestSessionRegisterRequestDto.kt
@@ -6,8 +6,8 @@ import kotlinx.serialization.Serializable
 import java.util.UUID
 
 @Serializable
-data class DatabasePreparationSelectQuestionRequestDto(
-    @SerialName("sessionQuestionId")
+data class DatabaseGuestSessionRegisterRequestDto(
+    @SerialName("id")
     @Serializable(UUIDSerializer::class)
-    val sessionQuestionId: UUID,
+    val id: UUID,
 )

--- a/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/in/DatabaseLearningFacilitatedPageQuery.kt
+++ b/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/in/DatabaseLearningFacilitatedPageQuery.kt
@@ -1,0 +1,15 @@
+package dev.kigya.headway.database.api.model.`in`
+
+import dev.kigya.headway.database.api.model.out.DatabaseLearningSkillGroup
+import dev.kigya.headway.database.api.model.out.DatabaseUserRole
+import java.util.UUID
+
+data class DatabaseLearningFacilitatedPageQuery(
+    val facilitatorUserId: UUID,
+    val facilitatorRole: DatabaseUserRole,
+    val locale: String,
+    val skillGroup: DatabaseLearningSkillGroup,
+    val limit: Int,
+    val afterQuestionId: Long?,
+    val subjectUserId: UUID?,
+)

--- a/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/in/DatabaseLearningRemarkCreateRequestDto.kt
+++ b/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/in/DatabaseLearningRemarkCreateRequestDto.kt
@@ -6,8 +6,10 @@ import kotlinx.serialization.Serializable
 import java.util.UUID
 
 @Serializable
-data class DatabasePreparationSelectQuestionRequestDto(
-    @SerialName("sessionQuestionId")
+data class DatabaseLearningRemarkCreateRequestDto(
+    @SerialName("subject_user_id")
     @Serializable(UUIDSerializer::class)
-    val sessionQuestionId: UUID,
+    val subjectUserId: UUID,
+    @SerialName("body")
+    val body: String,
 )

--- a/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/in/DatabasePreparationStartSessionRequestDto.kt
+++ b/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/in/DatabasePreparationStartSessionRequestDto.kt
@@ -3,14 +3,19 @@ package dev.kigya.headway.database.api.model.`in`
 import dev.kigya.headway.common.serialization.UUIDSerializer
 import dev.kigya.headway.database.api.model.out.DatabasePreparationFormatCode
 import dev.kigya.headway.database.api.model.out.DatabasePreparationQuestionDomain
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.util.UUID
 
 @Serializable
 data class DatabasePreparationStartSessionRequestDto(
+    @SerialName("subjectUserId")
     @Serializable(UUIDSerializer::class)
     val subjectUserId: UUID,
+    @SerialName("formatCode")
     val formatCode: DatabasePreparationFormatCode,
+    @SerialName("preparationLanguage")
     val preparationLanguage: String? = null,
+    @SerialName("customDomainFilter")
     val customDomainFilter: DatabasePreparationQuestionDomain? = null,
 )

--- a/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/in/DatabasePreparationSubmitOutcomeRequestDto.kt
+++ b/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/in/DatabasePreparationSubmitOutcomeRequestDto.kt
@@ -2,13 +2,17 @@ package dev.kigya.headway.database.api.model.`in`
 
 import dev.kigya.headway.common.serialization.UUIDSerializer
 import dev.kigya.headway.database.api.model.out.DatabasePreparationOutcomeCode
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.util.UUID
 
 @Serializable
 data class DatabasePreparationSubmitOutcomeRequestDto(
+    @SerialName("sessionQuestionId")
     @Serializable(UUIDSerializer::class)
     val sessionQuestionId: UUID,
+    @SerialName("outcome")
     val outcome: DatabasePreparationOutcomeCode,
+    @SerialName("comment")
     val comment: String? = null,
 )

--- a/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/out/DatabaseLearningModels.kt
+++ b/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/out/DatabaseLearningModels.kt
@@ -1,0 +1,93 @@
+package dev.kigya.headway.database.api.model.out
+
+import dev.kigya.headway.common.serialization.UUIDSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.util.UUID
+
+@Serializable
+enum class DatabaseLearningSkillGroup {
+    @SerialName("HARD")
+    HARD,
+
+    @SerialName("SOFT")
+    SOFT,
+}
+
+@Serializable
+enum class DatabaseLearningProgressState {
+    @SerialName("NOT_ANSWERED")
+    NOT_ANSWERED,
+
+    @SerialName("PARTIALLY_ANSWERED")
+    PARTIALLY_ANSWERED,
+
+    @SerialName("ANSWERED")
+    ANSWERED,
+}
+
+@Serializable
+data class DatabaseLearningTagDto(
+    @SerialName("id")
+    val id: Long,
+    @SerialName("label")
+    val label: String,
+)
+
+@Serializable
+data class DatabaseLearningQuestionDto(
+    @SerialName("id")
+    val id: Long,
+    @SerialName("skillGroup")
+    val skillGroup: DatabaseLearningSkillGroup,
+    @SerialName("text")
+    val text: String,
+    @SerialName("tags")
+    val tags: List<DatabaseLearningTagDto>,
+    @SerialName("progress")
+    val progress: DatabaseLearningProgressState?,
+)
+
+@Serializable
+data class DatabaseLearningCatalogResponseDto(
+    @SerialName("hardSkills")
+    val hardSkills: List<DatabaseLearningQuestionDto>,
+    @SerialName("softSkills")
+    val softSkills: List<DatabaseLearningQuestionDto>,
+    @SerialName("resumeHard")
+    val resumeHard: Long?,
+    @SerialName("resumeSoft")
+    val resumeSoft: Long?,
+)
+
+@Serializable
+data class DatabaseLearningPageResponseDto(
+    @SerialName("items")
+    val items: List<DatabaseLearningQuestionDto>,
+    @SerialName("resumeHard")
+    val resumeHard: Long?,
+    @SerialName("resumeSoft")
+    val resumeSoft: Long?,
+)
+
+@Serializable
+data class DatabaseLearningSearchResponseDto(
+    @SerialName("hardSkills")
+    val hardSkills: List<DatabaseLearningQuestionDto>,
+    @SerialName("softSkills")
+    val softSkills: List<DatabaseLearningQuestionDto>,
+)
+
+@Serializable
+data class DatabaseLearningRemarkDto(
+    @SerialName("id")
+    @Serializable(UUIDSerializer::class)
+    val id: UUID,
+    @SerialName("authorUserId")
+    @Serializable(UUIDSerializer::class)
+    val authorUserId: UUID,
+    @SerialName("body")
+    val body: String,
+    @SerialName("createdAtEpochMillis")
+    val createdAtEpochMillis: Long,
+)

--- a/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/out/DatabasePreparationCatalogResponseDto.kt
+++ b/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/out/DatabasePreparationCatalogResponseDto.kt
@@ -1,18 +1,26 @@
 package dev.kigya.headway.database.api.model.out
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class DatabasePreparationCatalogResponseDto(
+    @SerialName("items")
     val items: List<DatabasePreparationCatalogItemDto>,
 )
 
 @Serializable
 data class DatabasePreparationCatalogItemDto(
+    @SerialName("formatCode")
     val formatCode: DatabasePreparationFormatCode,
+    @SerialName("displayName")
     val displayName: String,
+    @SerialName("shortDescription")
     val shortDescription: String,
+    @SerialName("typeTags")
     val typeTags: List<String>,
+    @SerialName("defaultPreparationLanguage")
     val defaultPreparationLanguage: String? = null,
+    @SerialName("selectablePreparationLanguages")
     val selectablePreparationLanguages: List<String> = emptyList(),
 )

--- a/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/out/DatabasePreparationReadinessResponseDto.kt
+++ b/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/out/DatabasePreparationReadinessResponseDto.kt
@@ -1,10 +1,14 @@
 package dev.kigya.headway.database.api.model.out
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class DatabasePreparationReadinessResponseDto(
+    @SerialName("readinessPercent")
     val readinessPercent: Short? = null,
+    @SerialName("recommendedFormatCode")
     val recommendedFormatCode: DatabasePreparationFormatCode,
+    @SerialName("recommendedLabel")
     val recommendedLabel: String? = null,
 )

--- a/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/out/DatabasePreparationSessionStateDto.kt
+++ b/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/out/DatabasePreparationSessionStateDto.kt
@@ -1,58 +1,88 @@
 package dev.kigya.headway.database.api.model.out
 
 import dev.kigya.headway.common.serialization.UUIDSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.util.UUID
 
 @Serializable
 data class DatabasePreparationStartSessionResponseDto(
+    @SerialName("sessionId")
     @Serializable(UUIDSerializer::class)
     val sessionId: UUID,
+    @SerialName("state")
     val state: DatabasePreparationSessionStateDto,
 )
 
 @Serializable
 data class DatabasePreparationSessionStateDto(
+    @SerialName("sessionId")
     @Serializable(UUIDSerializer::class)
     val sessionId: UUID,
+    @SerialName("status")
     val status: DatabasePreparationSessionStatus,
+    @SerialName("formatCode")
     val formatCode: DatabasePreparationFormatCode,
+    @SerialName("preparationLanguage")
     val preparationLanguage: String,
+    @SerialName("facilitatorUserId")
     @Serializable(UUIDSerializer::class)
     val facilitatorUserId: UUID,
+    @SerialName("subjectUserId")
     @Serializable(UUIDSerializer::class)
     val subjectUserId: UUID,
+    @SerialName("subjectDisplayName")
     val subjectDisplayName: String,
+    @SerialName("subjectAvatarUrl")
     val subjectAvatarUrl: String? = null,
+    @SerialName("currentQuestionId")
     @Serializable(UUIDSerializer::class)
     val currentQuestionId: UUID? = null,
+    @SerialName("lastActiveQuestionId")
     @Serializable(UUIDSerializer::class)
     val lastActiveQuestionId: UUID? = null,
+    @SerialName("customDomainFilter")
     val customDomainFilter: DatabasePreparationQuestionDomain? = null,
+    @SerialName("questions")
     val questions: List<DatabasePreparationSessionQuestionDto>,
+    @SerialName("startedAtEpochMillis")
     val startedAtEpochMillis: Long,
+    @SerialName("endedAtEpochMillis")
     val endedAtEpochMillis: Long? = null,
 )
 
 @Serializable
 data class DatabasePreparationSessionQuestionDto(
+    @SerialName("id")
     @Serializable(UUIDSerializer::class)
     val id: UUID,
+    @SerialName("sortOrder")
     val sortOrder: Int,
+    @SerialName("topicTags")
     val topicTags: List<String>,
+    @SerialName("domain")
     val domain: DatabasePreparationQuestionDomain? = null,
+    @SerialName("titleOrPrompt")
     val titleOrPrompt: String,
+    @SerialName("body")
     val body: String? = null,
+    @SerialName("outcome")
     val outcome: DatabasePreparationOutcomeCode? = null,
+    @SerialName("comment")
     val comment: String? = null,
+    @SerialName("addressedForUi")
     val addressedForUi: Boolean,
 )
 
 @Serializable
 data class DatabasePreparationSessionSummaryDto(
+    @SerialName("sessionId")
     @Serializable(UUIDSerializer::class)
     val sessionId: UUID,
+    @SerialName("durationSeconds")
     val durationSeconds: Long,
+    @SerialName("headline")
     val headline: String,
+    @SerialName("body")
     val body: String,
 )

--- a/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/resource/DatabaseResource.kt
+++ b/server/database/api/src/main/kotlin/dev/kigya/headway/database/api/model/resource/DatabaseResource.kt
@@ -1,6 +1,7 @@
 package dev.kigya.headway.database.api.model.resource
 
 import dev.kigya.headway.common.serialization.UUIDSerializer
+import dev.kigya.headway.database.api.model.out.DatabaseLearningSkillGroup
 import dev.kigya.headway.database.api.model.out.DatabaseUserRole
 import io.ktor.resources.Resource
 import kotlinx.serialization.SerialName
@@ -13,11 +14,12 @@ class DatabaseResource {
 
     @Serializable
     @Resource("user")
-    data class User(val parent: DatabaseResource = DatabaseResource()) {
+    data class User(@SerialName("parent") val parent: DatabaseResource = DatabaseResource()) {
 
         @Serializable
         @Resource("")
         data class Query(
+            @SerialName("parent")
             val parent: User = User(),
             @SerialName("google_id")
             val googleId: String? = null,
@@ -28,15 +30,15 @@ class DatabaseResource {
 
         @Serializable
         @Resource("invite")
-        data class Invite(val parent: User = User())
+        data class Invite(@SerialName("parent") val parent: User = User())
 
         @Serializable
         @Resource("google")
-        data class Google(val parent: User = User()) {
+        data class Google(@SerialName("parent") val parent: User = User()) {
 
             @Serializable
             @Resource("upsert")
-            data class Upsert(val parent: Google = Google())
+            data class Upsert(@SerialName("parent") val parent: Google = Google())
         }
     }
 
@@ -47,17 +49,19 @@ class DatabaseResource {
         @Serializable
         @Resource("validate")
         data class Validate(
+            @SerialName("parent")
             val parent: Session = Session(),
         )
     }
 
     @Serializable
     @Resource("preparation")
-    data class Preparation(val parent: DatabaseResource = DatabaseResource()) {
+    data class Preparation(@SerialName("parent") val parent: DatabaseResource = DatabaseResource()) {
 
         @Serializable
         @Resource("setup/employees")
         data class SetupEmployees(
+            @SerialName("parent")
             val parent: Preparation = Preparation(),
             @SerialName("facilitator_user_id")
             @Serializable(UUIDSerializer::class)
@@ -69,7 +73,9 @@ class DatabaseResource {
         @Serializable
         @Resource("employees/{subjectUserId}/readiness")
         data class EmployeeReadiness(
+            @SerialName("parent")
             val parent: Preparation = Preparation(),
+            @SerialName("subjectUserId")
             @Serializable(UUIDSerializer::class)
             val subjectUserId: UUID,
             @SerialName("facilitator_user_id")
@@ -82,7 +88,9 @@ class DatabaseResource {
         @Serializable
         @Resource("catalog")
         data class Catalog(
+            @SerialName("parent")
             val parent: Preparation = Preparation(),
+            @SerialName("locale")
             val locale: String,
             @SerialName("facilitator_user_id")
             @Serializable(UUIDSerializer::class)
@@ -94,6 +102,7 @@ class DatabaseResource {
         @Serializable
         @Resource("sessions")
         data class Sessions(
+            @SerialName("parent")
             val parent: Preparation = Preparation(),
             @SerialName("facilitator_user_id")
             @Serializable(UUIDSerializer::class)
@@ -105,7 +114,9 @@ class DatabaseResource {
             @Serializable
             @Resource("{sessionId}")
             data class ById(
+                @SerialName("parent")
                 val parent: Sessions,
+                @SerialName("sessionId")
                 @Serializable(UUIDSerializer::class)
                 val sessionId: UUID,
                 @SerialName("facilitator_user_id")
@@ -118,28 +129,208 @@ class DatabaseResource {
                 @Serializable
                 @Resource("outcomes")
                 data class Outcomes(
+                    @SerialName("parent")
                     val parent: ById,
                 )
 
                 @Serializable
                 @Resource("select-question")
                 data class SelectQuestion(
+                    @SerialName("parent")
                     val parent: ById,
                 )
 
                 @Serializable
                 @Resource("finish")
                 data class Finish(
+                    @SerialName("parent")
                     val parent: ById,
                 )
 
                 @Serializable
                 @Resource("summary")
                 data class Summary(
+                    @SerialName("parent")
                     val parent: ById,
+                    @SerialName("locale")
                     val locale: String,
                 )
             }
         }
+    }
+
+    @Serializable
+    @Resource("learning-questions")
+    data class LearningQuestions(@SerialName("parent") val parent: DatabaseResource = DatabaseResource()) {
+
+        @Serializable
+        @Resource("public/catalog")
+        data class PublicCatalog(
+            @SerialName("parent")
+            val parent: LearningQuestions = LearningQuestions(),
+            @SerialName("locale")
+            val locale: String,
+        )
+
+        @Serializable
+        @Resource("public/page")
+        data class PublicPage(
+            @SerialName("parent")
+            val parent: LearningQuestions = LearningQuestions(),
+            @SerialName("locale")
+            val locale: String,
+            @SerialName("skill_group")
+            val skillGroup: DatabaseLearningSkillGroup,
+            @SerialName("limit")
+            val limit: Int,
+            @SerialName("after_question_id")
+            val afterQuestionId: Long? = null,
+        )
+
+        @Serializable
+        @Resource("public/search")
+        data class PublicSearch(
+            @SerialName("parent")
+            val parent: LearningQuestions = LearningQuestions(),
+            @SerialName("locale")
+            val locale: String,
+            @SerialName("q")
+            val q: String,
+        )
+
+        @Serializable
+        @Resource("public/{questionId}")
+        data class PublicById(
+            @SerialName("parent")
+            val parent: LearningQuestions = LearningQuestions(),
+            @SerialName("questionId")
+            val questionId: Long,
+            @SerialName("locale")
+            val locale: String,
+        )
+
+        @Serializable
+        @Resource("catalog")
+        data class Catalog(
+            @SerialName("parent")
+            val parent: LearningQuestions = LearningQuestions(),
+            @SerialName("locale")
+            val locale: String,
+            @SerialName("facilitator_user_id")
+            @Serializable(UUIDSerializer::class)
+            val facilitatorUserId: UUID,
+            @SerialName("facilitator_role")
+            val facilitatorRole: DatabaseUserRole,
+            @SerialName("subject_user_id")
+            @Serializable(UUIDSerializer::class)
+            val subjectUserId: UUID?,
+        )
+
+        @Serializable
+        @Resource("page")
+        data class Page(
+            @SerialName("parent")
+            val parent: LearningQuestions = LearningQuestions(),
+            @SerialName("locale")
+            val locale: String,
+            @SerialName("skill_group")
+            val skillGroup: DatabaseLearningSkillGroup,
+            @SerialName("limit")
+            val limit: Int,
+            @SerialName("after_question_id")
+            val afterQuestionId: Long? = null,
+            @SerialName("facilitator_user_id")
+            @Serializable(UUIDSerializer::class)
+            val facilitatorUserId: UUID,
+            @SerialName("facilitator_role")
+            val facilitatorRole: DatabaseUserRole,
+            @SerialName("subject_user_id")
+            @Serializable(UUIDSerializer::class)
+            val subjectUserId: UUID?,
+        )
+
+        @Serializable
+        @Resource("search")
+        data class Search(
+            @SerialName("parent")
+            val parent: LearningQuestions = LearningQuestions(),
+            @SerialName("locale")
+            val locale: String,
+            @SerialName("q")
+            val q: String,
+            @SerialName("facilitator_user_id")
+            @Serializable(UUIDSerializer::class)
+            val facilitatorUserId: UUID,
+            @SerialName("facilitator_role")
+            val facilitatorRole: DatabaseUserRole,
+            @SerialName("subject_user_id")
+            @Serializable(UUIDSerializer::class)
+            val subjectUserId: UUID?,
+        )
+
+        @Serializable
+        @Resource("{questionId}")
+        data class ById(
+            @SerialName("parent")
+            val parent: LearningQuestions = LearningQuestions(),
+            @SerialName("questionId")
+            val questionId: Long,
+            @SerialName("locale")
+            val locale: String,
+            @SerialName("facilitator_user_id")
+            @Serializable(UUIDSerializer::class)
+            val facilitatorUserId: UUID,
+            @SerialName("facilitator_role")
+            val facilitatorRole: DatabaseUserRole,
+            @SerialName("subject_user_id")
+            @Serializable(UUIDSerializer::class)
+            val subjectUserId: UUID?,
+        )
+
+        @Serializable
+        @Resource("{questionId}/remarks")
+        data class Remarks(
+            @SerialName("parent")
+            val parent: LearningQuestions = LearningQuestions(),
+            @SerialName("questionId")
+            val questionId: Long,
+            @SerialName("subject_user_id")
+            @Serializable(UUIDSerializer::class)
+            val subjectUserId: UUID,
+            @SerialName("facilitator_user_id")
+            @Serializable(UUIDSerializer::class)
+            val facilitatorUserId: UUID,
+            @SerialName("facilitator_role")
+            val facilitatorRole: DatabaseUserRole,
+        )
+    }
+
+    @Serializable
+    @Resource("guest-sessions")
+    data class GuestSessions(@SerialName("parent") val parent: DatabaseResource = DatabaseResource()) {
+
+        @Serializable
+        @Resource("")
+        data class Register(@SerialName("parent") val parent: GuestSessions = GuestSessions())
+
+        @Serializable
+        @Resource("{sessionId}/revoke")
+        data class Revoke(
+            @SerialName("parent")
+            val parent: GuestSessions = GuestSessions(),
+            @SerialName("sessionId")
+            @Serializable(UUIDSerializer::class)
+            val sessionId: UUID,
+        )
+
+        @Serializable
+        @Resource("{sessionId}/validate")
+        data class Validate(
+            @SerialName("parent")
+            val parent: GuestSessions = GuestSessions(),
+            @SerialName("sessionId")
+            @Serializable(UUIDSerializer::class)
+            val sessionId: UUID,
+        )
     }
 }

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/DatabaseApplication.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/DatabaseApplication.kt
@@ -35,6 +35,8 @@ private fun Application.databaseApp() {
             createSession = get(),
             validateSession = get(),
             preparation = get(),
+            learningQuestions = get(),
+            guestSessions = get(),
         ),
     )
 }

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/learning/LearningQuestionPreparationSync.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/learning/LearningQuestionPreparationSync.kt
@@ -1,0 +1,80 @@
+package dev.kigya.headway.database.internal.data.learning
+
+import dev.kigya.headway.database.api.model.out.DatabasePreparationOutcomeCode
+import dev.kigya.headway.database.internal.data.table.LearningQuestionPartialRemarkTable
+import dev.kigya.headway.database.internal.data.table.LearningQuestionProgressState
+import dev.kigya.headway.database.internal.data.table.LearningQuestionProgressTable
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.datetime.CurrentTimestampWithTimeZone
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.update
+import java.util.UUID
+
+internal class LearningQuestionPreparationSync {
+
+    fun recordPreparationOutcome(
+        subjectUserId: UUID,
+        bankQuestionId: Long,
+        outcome: DatabasePreparationOutcomeCode,
+    ) {
+        when (outcome) {
+            DatabasePreparationOutcomeCode.GOOD -> {
+                upsertProgressState(subjectUserId, bankQuestionId, LearningQuestionProgressState.ANSWERED)
+                LearningQuestionPartialRemarkTable.deleteWhere {
+                    (LearningQuestionPartialRemarkTable.subjectUserId eq subjectUserId) and
+                        (LearningQuestionPartialRemarkTable.questionId eq bankQuestionId)
+                }
+            }
+
+            DatabasePreparationOutcomeCode.PARTIAL ->
+                upsertProgressState(
+                    subjectUserId,
+                    bankQuestionId,
+                    LearningQuestionProgressState.PARTIALLY_ANSWERED,
+                )
+
+            DatabasePreparationOutcomeCode.NOT_ANSWERED -> {
+                LearningQuestionProgressTable.deleteWhere {
+                    (LearningQuestionProgressTable.subjectUserId eq subjectUserId) and
+                        (LearningQuestionProgressTable.questionId eq bankQuestionId)
+                }
+                LearningQuestionPartialRemarkTable.deleteWhere {
+                    (LearningQuestionPartialRemarkTable.subjectUserId eq subjectUserId) and
+                        (LearningQuestionPartialRemarkTable.questionId eq bankQuestionId)
+                }
+            }
+        }
+    }
+
+    private fun upsertProgressState(
+        subjectUserId: UUID,
+        questionId: Long,
+        state: LearningQuestionProgressState,
+    ) {
+        val existing = LearningQuestionProgressTable.selectAll()
+            .where {
+                (LearningQuestionProgressTable.subjectUserId eq subjectUserId) and
+                    (LearningQuestionProgressTable.questionId eq questionId)
+            }
+            .firstOrNull()
+        if (existing == null) {
+            LearningQuestionProgressTable.insert {
+                it[LearningQuestionProgressTable.subjectUserId] = subjectUserId
+                it[LearningQuestionProgressTable.questionId] = questionId
+                it[LearningQuestionProgressTable.state] = state
+                it[LearningQuestionProgressTable.updatedAt] = CurrentTimestampWithTimeZone
+            }
+        } else {
+            LearningQuestionProgressTable.update({
+                (LearningQuestionProgressTable.subjectUserId eq subjectUserId) and
+                    (LearningQuestionProgressTable.questionId eq questionId)
+            }) {
+                it[LearningQuestionProgressTable.state] = state
+                it[LearningQuestionProgressTable.updatedAt] = CurrentTimestampWithTimeZone
+            }
+        }
+    }
+}

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/model/ExposedAccountStatus.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/model/ExposedAccountStatus.kt
@@ -1,10 +1,16 @@
 package dev.kigya.headway.database.internal.data.model
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 internal enum class ExposedAccountStatus(val slug: String) {
+    @SerialName("INVITED")
     INVITED("INVITED"),
+
+    @SerialName("ACTIVE")
     ACTIVE("ACTIVE"),
+
+    @SerialName("REVOKED")
     REVOKED("REVOKED"),
 }

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/repository/GuestSessionsRepository.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/repository/GuestSessionsRepository.kt
@@ -1,0 +1,49 @@
+package dev.kigya.headway.database.internal.data.repository
+
+import dev.kigya.headway.database.internal.core.extension.dbQuery
+import dev.kigya.headway.database.internal.data.table.GuestSessionTable
+import dev.kigya.headway.database.internal.domain.error.DatabaseException
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.datetime.CurrentTimestampWithTimeZone
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.update
+import java.util.UUID
+
+internal class GuestSessionsRepository(
+    private val database: Database,
+) {
+
+    suspend fun register(sessionId: UUID) = database.dbQuery {
+        val exists = GuestSessionTable.selectAll()
+            .where { GuestSessionTable.id eq sessionId }
+            .firstOrNull() != null
+        if (!exists) {
+            GuestSessionTable.insert {
+                it[id] = sessionId
+                it[createdAt] = CurrentTimestampWithTimeZone
+                it[revokedAt] = null
+            }
+        }
+    }
+
+    suspend fun revoke(sessionId: UUID) = database.dbQuery {
+        val updated = GuestSessionTable.update({ GuestSessionTable.id eq sessionId }) {
+            it[revokedAt] = CurrentTimestampWithTimeZone
+        }
+        if (updated == 0) {
+            throw DatabaseException.NotFound("Guest session not found")
+        }
+    }
+
+    suspend fun ensureActive(sessionId: UUID) = database.dbQuery {
+        val row = GuestSessionTable.selectAll()
+            .where { GuestSessionTable.id eq sessionId }
+            .firstOrNull()
+            ?: throw DatabaseException.NotFound("Guest session not found")
+        if (row[GuestSessionTable.revokedAt] != null) {
+            throw DatabaseException.Forbidden(message = "Guest session revoked")
+        }
+    }
+}

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/repository/LearningQuestionRemarksRepository.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/repository/LearningQuestionRemarksRepository.kt
@@ -1,0 +1,92 @@
+package dev.kigya.headway.database.internal.data.repository
+
+import dev.kigya.headway.database.api.model.out.DatabaseLearningRemarkDto
+import dev.kigya.headway.database.internal.core.extension.dbQuery
+import dev.kigya.headway.database.internal.data.table.LearningQuestionPartialRemarkTable
+import dev.kigya.headway.database.internal.data.table.LearningQuestionProgressState
+import dev.kigya.headway.database.internal.data.table.LearningQuestionProgressTable
+import dev.kigya.headway.database.internal.domain.error.DatabaseException
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.datetime.CurrentTimestampWithTimeZone
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import java.util.UUID
+
+internal class LearningQuestionRemarksRepository(
+    private val database: Database,
+) {
+
+    suspend fun listRemarks(
+        questionId: Long,
+        subjectUserId: UUID,
+    ): List<DatabaseLearningRemarkDto> = database.dbQuery {
+        val progress = LearningQuestionProgressTable.selectAll()
+            .where {
+                (LearningQuestionProgressTable.subjectUserId eq subjectUserId) and
+                    (LearningQuestionProgressTable.questionId eq questionId)
+            }
+            .firstOrNull()
+            ?.get(LearningQuestionProgressTable.state)
+        if (progress != LearningQuestionProgressState.PARTIALLY_ANSWERED) {
+            return@dbQuery emptyList()
+        }
+        LearningQuestionPartialRemarkTable.selectAll()
+            .where {
+                (LearningQuestionPartialRemarkTable.subjectUserId eq subjectUserId) and
+                    (LearningQuestionPartialRemarkTable.questionId eq questionId)
+            }
+            .orderBy(LearningQuestionPartialRemarkTable.createdAt to SortOrder.ASC)
+            .map { row ->
+                DatabaseLearningRemarkDto(
+                    id = row[LearningQuestionPartialRemarkTable.id].value,
+                    authorUserId = row[LearningQuestionPartialRemarkTable.authorUserId].value,
+                    body = row[LearningQuestionPartialRemarkTable.body],
+                    createdAtEpochMillis = row[LearningQuestionPartialRemarkTable.createdAt]
+                        .toInstant()
+                        .toEpochMilli(),
+                )
+            }
+    }
+
+    suspend fun insertRemark(
+        questionId: Long,
+        subjectUserId: UUID,
+        authorUserId: UUID,
+        body: String,
+    ): DatabaseLearningRemarkDto = database.dbQuery {
+        val progress = LearningQuestionProgressTable.selectAll()
+            .where {
+                (LearningQuestionProgressTable.subjectUserId eq subjectUserId) and
+                    (LearningQuestionProgressTable.questionId eq questionId)
+            }
+            .firstOrNull()
+            ?.get(LearningQuestionProgressTable.state)
+            ?: throw DatabaseException.InvalidRequest("Learning progress required before remarks")
+        if (progress != LearningQuestionProgressState.PARTIALLY_ANSWERED) {
+            throw DatabaseException.InvalidRequest("Remarks are only available for partially answered questions")
+        }
+        val remarkId = UUID.randomUUID()
+        LearningQuestionPartialRemarkTable.insert {
+            it[id] = remarkId
+            it[LearningQuestionPartialRemarkTable.subjectUserId] = subjectUserId
+            it[LearningQuestionPartialRemarkTable.questionId] = questionId
+            it[LearningQuestionPartialRemarkTable.authorUserId] = authorUserId
+            it[LearningQuestionPartialRemarkTable.body] = body
+            it[LearningQuestionPartialRemarkTable.createdAt] = CurrentTimestampWithTimeZone
+        }
+        val row = LearningQuestionPartialRemarkTable.selectAll()
+            .where { LearningQuestionPartialRemarkTable.id eq remarkId }
+            .single()
+        DatabaseLearningRemarkDto(
+            id = row[LearningQuestionPartialRemarkTable.id].value,
+            authorUserId = row[LearningQuestionPartialRemarkTable.authorUserId].value,
+            body = row[LearningQuestionPartialRemarkTable.body],
+            createdAtEpochMillis = row[LearningQuestionPartialRemarkTable.createdAt]
+                .toInstant()
+                .toEpochMilli(),
+        )
+    }
+}

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/repository/LearningQuestionsReadRepository.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/repository/LearningQuestionsReadRepository.kt
@@ -1,0 +1,569 @@
+@file:Suppress("TooManyFunctions")
+
+package dev.kigya.headway.database.internal.data.repository
+
+import dev.kigya.headway.database.api.model.`in`.DatabaseLearningFacilitatedPageQuery
+import dev.kigya.headway.database.api.model.out.DatabaseLearningCatalogResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningPageResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningProgressState
+import dev.kigya.headway.database.api.model.out.DatabaseLearningQuestionDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningSearchResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningSkillGroup
+import dev.kigya.headway.database.api.model.out.DatabaseLearningTagDto
+import dev.kigya.headway.database.api.model.out.DatabaseUserRole
+import dev.kigya.headway.database.internal.core.extension.dbQuery
+import dev.kigya.headway.database.internal.data.scope.ensureEmployeeSelfSubject
+import dev.kigya.headway.database.internal.data.scope.isSubjectInFacilitatorLearningScope
+import dev.kigya.headway.database.internal.data.table.LearningQuestionProgressState
+import dev.kigya.headway.database.internal.data.table.LearningQuestionProgressTable
+import dev.kigya.headway.database.internal.data.table.QuestionLocaleCode
+import dev.kigya.headway.database.internal.data.table.QuestionLocalesTable
+import dev.kigya.headway.database.internal.data.table.QuestionSkillGroup
+import dev.kigya.headway.database.internal.data.table.QuestionTagsTable
+import dev.kigya.headway.database.internal.data.table.QuestionsTable
+import dev.kigya.headway.database.internal.data.table.TagsTable
+import dev.kigya.headway.database.internal.domain.error.DatabaseException
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import java.util.UUID
+
+internal class LearningQuestionsReadRepository(
+    private val database: Database,
+) {
+
+    suspend fun loadPublicCatalog(locale: String): DatabaseLearningCatalogResponseDto =
+        database.dbQuery {
+            buildCatalog(
+                preferredLocale = normalizeLocale(locale),
+                subjectUserId = null,
+            )
+        }
+
+    suspend fun loadCatalog(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        locale: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningCatalogResponseDto = database.dbQuery {
+        val subject = resolveSubjectUserId(
+            facilitatorUserId = facilitatorUserId,
+            facilitatorRole = facilitatorRole,
+            subjectUserId = subjectUserId,
+        )
+        buildCatalog(
+            preferredLocale = normalizeLocale(locale),
+            subjectUserId = subject,
+        )
+    }
+
+    suspend fun loadPublicPage(
+        locale: String,
+        skillGroup: DatabaseLearningSkillGroup,
+        limit: Int,
+        afterQuestionId: Long?,
+    ): DatabaseLearningPageResponseDto = database.dbQuery {
+        buildPage(
+            preferredLocale = normalizeLocale(locale),
+            skillGroup = toInternalSkillGroup(skillGroup),
+            limit = limit,
+            afterQuestionId = afterQuestionId,
+            subjectUserId = null,
+        )
+    }
+
+    suspend fun loadPage(
+        query: DatabaseLearningFacilitatedPageQuery,
+    ): DatabaseLearningPageResponseDto = database.dbQuery {
+        val subject = resolveSubjectUserId(
+            facilitatorUserId = query.facilitatorUserId,
+            facilitatorRole = query.facilitatorRole,
+            subjectUserId = query.subjectUserId,
+        )
+        buildPage(
+            preferredLocale = normalizeLocale(query.locale),
+            skillGroup = toInternalSkillGroup(query.skillGroup),
+            limit = query.limit,
+            afterQuestionId = query.afterQuestionId,
+            subjectUserId = subject,
+        )
+    }
+
+    suspend fun loadPublicSearch(
+        locale: String,
+        query: String,
+    ): DatabaseLearningSearchResponseDto = database.dbQuery {
+        buildSearch(
+            preferredLocale = normalizeLocale(locale),
+            rawQuery = query,
+            subjectUserId = null,
+        )
+    }
+
+    suspend fun loadSearch(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        locale: String,
+        query: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningSearchResponseDto = database.dbQuery {
+        val subject = resolveSubjectUserId(
+            facilitatorUserId = facilitatorUserId,
+            facilitatorRole = facilitatorRole,
+            subjectUserId = subjectUserId,
+        )
+        buildSearch(
+            preferredLocale = normalizeLocale(locale),
+            rawQuery = query,
+            subjectUserId = subject,
+        )
+    }
+
+    suspend fun loadPublicQuestionById(
+        questionId: Long,
+        locale: String,
+    ): DatabaseLearningQuestionDto = database.dbQuery {
+        loadSingleQuestion(
+            questionId = questionId,
+            preferredLocale = normalizeLocale(locale),
+            subjectUserId = null,
+        )
+    }
+
+    suspend fun loadQuestionById(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        questionId: Long,
+        locale: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningQuestionDto = database.dbQuery {
+        val subject = resolveSubjectUserId(
+            facilitatorUserId = facilitatorUserId,
+            facilitatorRole = facilitatorRole,
+            subjectUserId = subjectUserId,
+        )
+        loadSingleQuestion(
+            questionId = questionId,
+            preferredLocale = normalizeLocale(locale),
+            subjectUserId = subject,
+        )
+    }
+}
+
+private fun resolveSubjectUserId(
+    facilitatorUserId: UUID,
+    facilitatorRole: DatabaseUserRole,
+    subjectUserId: UUID?,
+): UUID {
+    val subject = subjectUserId ?: facilitatorUserId
+    ensureEmployeeSelfSubject(
+        facilitatorId = facilitatorUserId,
+        facilitatorRole = facilitatorRole,
+        subjectUserId = subject,
+    )
+    if (!isSubjectInFacilitatorLearningScope(
+            facilitatorId = facilitatorUserId,
+            facilitatorRole = facilitatorRole,
+            subjectUserId = subject,
+        )
+    ) {
+        throw DatabaseException.Forbidden(message = "Subject not in facilitator scope")
+    }
+    return subject
+}
+
+private fun buildCatalog(
+    preferredLocale: QuestionLocaleCode,
+    subjectUserId: UUID?,
+): DatabaseLearningCatalogResponseDto {
+    val hardRows = loadActiveQuestionRows(QuestionSkillGroup.HARD)
+    val softRows = loadActiveQuestionRows(QuestionSkillGroup.SOFT)
+    val hardIds = hardRows.map { row -> row[QuestionsTable.id] }
+    val softIds = softRows.map { row -> row[QuestionsTable.id] }
+    val progress = loadProgressMaps(subjectUserId, hardIds + softIds)
+    val tagsByQuestion = loadTagDtosByQuestionId(hardIds + softIds, preferredLocale)
+    val hardDtos = hardRows.map { row ->
+        toQuestionDto(
+            row = row,
+            preferredLocale = preferredLocale,
+            tagsByQuestion = tagsByQuestion,
+            progress = progress,
+            subjectUserId = subjectUserId,
+        )
+    }
+    val softDtos = softRows.map { row ->
+        toQuestionDto(
+            row = row,
+            preferredLocale = preferredLocale,
+            tagsByQuestion = tagsByQuestion,
+            progress = progress,
+            subjectUserId = subjectUserId,
+        )
+    }
+    val (resumeHard, resumeSoft) = if (subjectUserId == null) {
+        null to null
+    } else {
+        resumePair(
+            hardIds = hardIds,
+            softIds = softIds,
+            touched = progress.keys,
+        )
+    }
+    return DatabaseLearningCatalogResponseDto(
+        hardSkills = hardDtos,
+        softSkills = softDtos,
+        resumeHard = resumeHard,
+        resumeSoft = resumeSoft,
+    )
+}
+
+private fun buildPage(
+    preferredLocale: QuestionLocaleCode,
+    skillGroup: QuestionSkillGroup,
+    limit: Int,
+    afterQuestionId: Long?,
+    subjectUserId: UUID?,
+): DatabaseLearningPageResponseDto {
+    val allRows = loadActiveQuestionRows(skillGroup)
+    val allIds = allRows.map { row -> row[QuestionsTable.id] }
+    val startIndex = when (afterQuestionId) {
+        null -> 0
+        else -> {
+            val idx = allIds.indexOf(afterQuestionId)
+            if (idx < 0) {
+                return DatabaseLearningPageResponseDto(
+                    items = emptyList(),
+                    resumeHard = null,
+                    resumeSoft = null,
+                )
+            }
+            idx + 1
+        }
+    }
+    val sliceIds = allIds.drop(startIndex).take(limit)
+    val rowsById = allRows.associateBy { row -> row[QuestionsTable.id] }
+    val progress = loadProgressMaps(subjectUserId, sliceIds)
+    val tagsByQuestion = loadTagDtosByQuestionId(sliceIds, preferredLocale)
+    val items = sliceIds.mapNotNull { qId ->
+        rowsById[qId]?.let { row ->
+            toQuestionDto(
+                row = row,
+                preferredLocale = preferredLocale,
+                tagsByQuestion = tagsByQuestion,
+                progress = progress,
+                subjectUserId = subjectUserId,
+            )
+        }
+    }
+    val hardIds = loadActiveQuestionRows(QuestionSkillGroup.HARD).map { it[QuestionsTable.id] }
+    val softIds = loadActiveQuestionRows(QuestionSkillGroup.SOFT).map { it[QuestionsTable.id] }
+    val fullProgress = loadProgressMaps(subjectUserId, hardIds + softIds)
+    val (resumeHard, resumeSoft) = if (subjectUserId == null) {
+        null to null
+    } else {
+        resumePair(
+            hardIds = hardIds,
+            softIds = softIds,
+            touched = fullProgress.keys,
+        )
+    }
+    return DatabaseLearningPageResponseDto(
+        items = items,
+        resumeHard = resumeHard,
+        resumeSoft = resumeSoft,
+    )
+}
+
+private fun buildSearch(
+    preferredLocale: QuestionLocaleCode,
+    rawQuery: String,
+    subjectUserId: UUID?,
+): DatabaseLearningSearchResponseDto {
+    val trimmed = rawQuery.trim()
+    if (trimmed.isEmpty()) {
+        return DatabaseLearningSearchResponseDto(
+            hardSkills = emptyList(),
+            softSkills = emptyList(),
+        )
+    }
+    val tokens = trimmed.split(TOKEN_SPLIT_REGEX).filter { it.isNotBlank() }.map { it.lowercase() }
+    if (tokens.isEmpty()) {
+        return DatabaseLearningSearchResponseDto(
+            hardSkills = emptyList(),
+            softSkills = emptyList(),
+        )
+    }
+    val hardHits = rankedSearchHits(
+        skillGroup = QuestionSkillGroup.HARD,
+        tokens = tokens,
+        preferredLocale = preferredLocale,
+        limit = SEARCH_CAP_PER_GROUP,
+    )
+    val softHits = rankedSearchHits(
+        skillGroup = QuestionSkillGroup.SOFT,
+        tokens = tokens,
+        preferredLocale = preferredLocale,
+        limit = SEARCH_CAP_PER_GROUP,
+    )
+    val allIds = (hardHits + softHits).distinct()
+    val progress = loadProgressMaps(subjectUserId, allIds)
+    val tagsByQuestion = loadTagDtosByQuestionId(allIds, preferredLocale)
+    val rowsById = loadRowsByIds(allIds)
+    fun mapHits(ids: List<Long>) = ids.mapNotNull { qId ->
+        rowsById[qId]?.let { row ->
+            toQuestionDto(
+                row = row,
+                preferredLocale = preferredLocale,
+                tagsByQuestion = tagsByQuestion,
+                progress = progress,
+                subjectUserId = subjectUserId,
+            )
+        }
+    }
+    return DatabaseLearningSearchResponseDto(
+        hardSkills = mapHits(hardHits),
+        softSkills = mapHits(softHits),
+    )
+}
+
+private fun rankedSearchHits(
+    skillGroup: QuestionSkillGroup,
+    tokens: List<String>,
+    preferredLocale: QuestionLocaleCode,
+    limit: Int,
+): List<Long> {
+    val rows = loadActiveQuestionRows(skillGroup)
+    val scored = rows.mapNotNull { row ->
+        val qId = row[QuestionsTable.id]
+        val text = localizedQuestionText(questionId = qId, preferredLocale = preferredLocale).lowercase()
+        val tagKeys = tagKeysForQuestion(qId).map { key -> key.lowercase() }
+        var score = 0
+        for (token in tokens) {
+            if (text.contains(token)) {
+                score += SEARCH_SCORE_TEXT_HIT
+            }
+            if (tagKeys.any { key -> key.contains(token) }) {
+                score += SEARCH_SCORE_TAG_HIT
+            }
+        }
+        if (score <= 0) {
+            return@mapNotNull null
+        }
+        Triple(
+            first = qId,
+            second = score,
+            third = row[QuestionsTable.displayPriority],
+        )
+    }
+    return scored
+        .sortedWith(
+            compareByDescending<Triple<Long, Int, Int?>> { it.second }
+                .thenBy { it.third == null }
+                .thenBy { it.third ?: Int.MAX_VALUE }
+                .thenBy { it.first },
+        )
+        .map { it.first }
+        .take(limit)
+}
+
+private fun loadSingleQuestion(
+    questionId: Long,
+    preferredLocale: QuestionLocaleCode,
+    subjectUserId: UUID?,
+): DatabaseLearningQuestionDto {
+    val row = QuestionsTable.selectAll()
+        .where { (QuestionsTable.id eq questionId) and (QuestionsTable.isActive eq true) }
+        .firstOrNull()
+        ?: throw DatabaseException.NotFound("Question not found")
+    val progress = loadProgressMaps(subjectUserId, listOf(questionId))
+    val tagsByQuestion = loadTagDtosByQuestionId(listOf(questionId), preferredLocale)
+    return toQuestionDto(
+        row = row,
+        preferredLocale = preferredLocale,
+        tagsByQuestion = tagsByQuestion,
+        progress = progress,
+        subjectUserId = subjectUserId,
+    )
+}
+
+private fun loadActiveQuestionRows(skillGroup: QuestionSkillGroup): List<ResultRow> =
+    QuestionsTable.selectAll()
+        .where {
+            (QuestionsTable.isActive eq true) and (QuestionsTable.skillGroup eq skillGroup)
+        }
+        .toList()
+        .sortedWith(learningQuestionRowComparator)
+
+private fun loadRowsByIds(ids: List<Long>): Map<Long, ResultRow> {
+    if (ids.isEmpty()) {
+        return emptyMap()
+    }
+    val predicate: Op<Boolean> = ids.toDisjunction { qId -> QuestionsTable.id eq qId }
+    return QuestionsTable.selectAll()
+        .where { predicate and (QuestionsTable.isActive eq true) }
+        .associateBy { r -> r[QuestionsTable.id] }
+}
+
+private fun loadProgressMaps(
+    subjectUserId: UUID?,
+    questionIds: List<Long>,
+): Map<Long, DatabaseLearningProgressState> {
+    if (subjectUserId == null || questionIds.isEmpty()) {
+        return emptyMap()
+    }
+    val predicate: Op<Boolean> = questionIds.toDisjunction { qId ->
+        LearningQuestionProgressTable.questionId eq qId
+    }
+    return LearningQuestionProgressTable.selectAll()
+        .where {
+            (LearningQuestionProgressTable.subjectUserId eq subjectUserId) and predicate
+        }
+        .associate { row ->
+            row[LearningQuestionProgressTable.questionId] to toWireProgressState(
+                row[LearningQuestionProgressTable.state],
+            )
+        }
+}
+
+private fun toQuestionDto(
+    row: ResultRow,
+    preferredLocale: QuestionLocaleCode,
+    tagsByQuestion: Map<Long, List<DatabaseLearningTagDto>>,
+    progress: Map<Long, DatabaseLearningProgressState>,
+    subjectUserId: UUID?,
+): DatabaseLearningQuestionDto {
+    val qId = row[QuestionsTable.id]
+    val skillGroup = toWireSkillGroup(row[QuestionsTable.skillGroup])
+    val text = localizedQuestionText(questionId = qId, preferredLocale = preferredLocale)
+    val progressValue = when (subjectUserId) {
+        null -> null
+        else -> progress[qId] ?: DatabaseLearningProgressState.NOT_ANSWERED
+    }
+    return DatabaseLearningQuestionDto(
+        id = qId,
+        skillGroup = skillGroup,
+        text = text,
+        tags = tagsByQuestion[qId].orEmpty(),
+        progress = progressValue,
+    )
+}
+
+private fun localizedQuestionText(
+    questionId: Long,
+    preferredLocale: QuestionLocaleCode,
+): String {
+    val rows = QuestionLocalesTable.selectAll()
+        .where { QuestionLocalesTable.questionId eq questionId }
+        .associate { r -> r[QuestionLocalesTable.locale] to r[QuestionLocalesTable.questionText] }
+    rows[preferredLocale]?.let { return it }
+    rows[QuestionLocaleCode.EN]?.let { return it }
+    rows[QuestionLocaleCode.RU]?.let { return it }
+    return "Question $questionId"
+}
+
+private fun loadTagDtosByQuestionId(
+    questionIds: List<Long>,
+    preferredLocale: QuestionLocaleCode,
+): Map<Long, List<DatabaseLearningTagDto>> {
+    if (questionIds.isEmpty()) {
+        return emptyMap()
+    }
+    val qp: Op<Boolean> = questionIds.toDisjunction { qId -> QuestionTagsTable.questionId eq qId }
+    val links = QuestionTagsTable.selectAll().where { qp }.toList()
+    if (links.isEmpty()) {
+        return emptyMap()
+    }
+    val tagIds = links.map { l -> l[QuestionTagsTable.tagId] }.distinct()
+    val tp: Op<Boolean> = tagIds.toDisjunction { tid -> TagsTable.id eq tid }
+    val tagKeys = TagsTable.selectAll().where { tp }.associate { r ->
+        r[TagsTable.id] to r[TagsTable.key]
+    }
+    return links.groupBy { l -> l[QuestionTagsTable.questionId] }
+        .mapValues { (_, linkRows) ->
+            linkRows.mapNotNull { link ->
+                val tid = link[QuestionTagsTable.tagId]
+                val key = tagKeys[tid] ?: return@mapNotNull null
+                DatabaseLearningTagDto(id = tid, label = key)
+            }
+        }
+}
+
+private fun tagKeysForQuestion(questionId: Long): List<String> {
+    val links = QuestionTagsTable.selectAll()
+        .where { QuestionTagsTable.questionId eq questionId }
+        .toList()
+    if (links.isEmpty()) {
+        return emptyList()
+    }
+    val tagIds = links.map { l -> l[QuestionTagsTable.tagId] }.distinct()
+    val tp: Op<Boolean> = tagIds.toDisjunction { tid -> TagsTable.id eq tid }
+    return TagsTable.selectAll().where { tp }.map { r -> r[TagsTable.key] }
+}
+
+private fun resumePair(
+    hardIds: List<Long>,
+    softIds: List<Long>,
+    touched: Set<Long>,
+): Pair<Long?, Long?> =
+    longestTouchedPrefixAnchor(hardIds, touched) to longestTouchedPrefixAnchor(softIds, touched)
+
+private fun longestTouchedPrefixAnchor(
+    orderedIds: List<Long>,
+    touched: Set<Long>,
+): Long? {
+    var last: Long? = null
+    for (id in orderedIds) {
+        if (id !in touched) {
+            break
+        }
+        last = id
+    }
+    return last
+}
+
+private val learningQuestionRowComparator: Comparator<ResultRow> =
+    compareBy<ResultRow> { row ->
+        row[QuestionsTable.displayPriority] == null
+    }.thenBy { row ->
+        row[QuestionsTable.displayPriority] ?: Int.MAX_VALUE
+    }.thenBy { row ->
+        row[QuestionsTable.id]
+    }
+
+private fun normalizeLocale(locale: String): QuestionLocaleCode {
+    val trimmed = locale.trim().lowercase()
+    return when {
+        trimmed.startsWith("ru") -> QuestionLocaleCode.RU
+        else -> QuestionLocaleCode.EN
+    }
+}
+
+private fun toInternalSkillGroup(group: DatabaseLearningSkillGroup): QuestionSkillGroup =
+    when (group) {
+        DatabaseLearningSkillGroup.HARD -> QuestionSkillGroup.HARD
+        DatabaseLearningSkillGroup.SOFT -> QuestionSkillGroup.SOFT
+    }
+
+private fun toWireSkillGroup(group: QuestionSkillGroup): DatabaseLearningSkillGroup = when (group) {
+    QuestionSkillGroup.HARD -> DatabaseLearningSkillGroup.HARD
+    QuestionSkillGroup.SOFT -> DatabaseLearningSkillGroup.SOFT
+}
+
+private fun toWireProgressState(
+    state: LearningQuestionProgressState,
+): DatabaseLearningProgressState = when (state) {
+    LearningQuestionProgressState.NOT_ANSWERED -> DatabaseLearningProgressState.NOT_ANSWERED
+    LearningQuestionProgressState.PARTIALLY_ANSWERED -> DatabaseLearningProgressState.PARTIALLY_ANSWERED
+    LearningQuestionProgressState.ANSWERED -> DatabaseLearningProgressState.ANSWERED
+}
+
+private val TOKEN_SPLIT_REGEX: Regex = "\\s+".toRegex()
+
+private const val SEARCH_CAP_PER_GROUP: Int = 25
+
+private const val SEARCH_SCORE_TEXT_HIT: Int = 2
+
+private const val SEARCH_SCORE_TAG_HIT: Int = 3

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/repository/PreparationRepository.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/repository/PreparationRepository.kt
@@ -14,6 +14,7 @@ import dev.kigya.headway.database.api.model.out.DatabasePreparationSessionSummar
 import dev.kigya.headway.database.api.model.out.DatabasePreparationStartSessionResponseDto
 import dev.kigya.headway.database.api.model.out.DatabaseUserRole
 import dev.kigya.headway.database.internal.core.extension.dbQuery
+import dev.kigya.headway.database.internal.data.learning.LearningQuestionPreparationSync
 import dev.kigya.headway.database.internal.data.model.ExposedAccountStatus
 import dev.kigya.headway.database.internal.data.table.EmployeePreparationPlanTable
 import dev.kigya.headway.database.internal.data.table.MentorshipsTable
@@ -50,6 +51,7 @@ import java.util.UUID
 internal class PreparationRepository(
     private val database: Database,
     private val buildSessionQuestionSnapshot: BuildSessionQuestionSnapshotUseCase,
+    private val learningQuestionPreparationSync: LearningQuestionPreparationSync,
 ) : PreparationRepositoryContract {
 
     override suspend fun listSetupEmployees(
@@ -246,6 +248,14 @@ internal class PreparationRepository(
             outcome = outcome,
             comment = comment?.trim()?.takeIf(String::isNotEmpty),
         )
+        val bankQuestionId = questionRow[SessionQuestionTable.sourceQuestionId]
+        if (bankQuestionId != null) {
+            learningQuestionPreparationSync.recordPreparationOutcome(
+                subjectUserId = sessionRow[PreparationSessionTable.subjectUserId].value,
+                bankQuestionId = bankQuestionId,
+                outcome = outcome,
+            )
+        }
         when (formatCode) {
             DatabasePreparationFormatCode.CUSTOM ->
                 PreparationSessionTable.update({ PreparationSessionTable.id eq sessionId }) {

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/scope/FacilitatorSubjectScope.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/scope/FacilitatorSubjectScope.kt
@@ -1,0 +1,68 @@
+package dev.kigya.headway.database.internal.data.scope
+
+import dev.kigya.headway.database.api.model.out.DatabaseUserRole
+import dev.kigya.headway.database.internal.data.model.ExposedAccountStatus
+import dev.kigya.headway.database.internal.data.table.MentorshipsTable
+import dev.kigya.headway.database.internal.data.table.UsersTable
+import dev.kigya.headway.database.internal.domain.error.DatabaseException
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import java.util.UUID
+
+internal fun isSubjectInFacilitatorLearningScope(
+    facilitatorId: UUID,
+    facilitatorRole: DatabaseUserRole,
+    subjectUserId: UUID,
+): Boolean {
+    val baseFilter: Op<Boolean> =
+        (UsersTable.id eq subjectUserId) and
+            (UsersTable.isActive eq true) and
+            (UsersTable.role eq DatabaseUserRole.EMPLOYEE) and
+            (UsersTable.status eq ExposedAccountStatus.ACTIVE)
+
+    return when (facilitatorRole) {
+        DatabaseUserRole.EMPLOYEE ->
+            subjectUserId == facilitatorId &&
+                UsersTable.selectAll().where { baseFilter }.firstOrNull() != null
+
+        DatabaseUserRole.DEVELOPER ->
+            UsersTable.selectAll().where { baseFilter }.firstOrNull() != null
+
+        DatabaseUserRole.MANAGER -> {
+            val facilitatorRow = UsersTable.selectAll()
+                .where { UsersTable.id eq facilitatorId }
+                .singleOrNull()
+                ?: return false
+            val department = facilitatorRow[UsersTable.department]
+            UsersTable.selectAll().where {
+                baseFilter and (UsersTable.department eq department)
+            }.firstOrNull() != null
+        }
+
+        DatabaseUserRole.MENTOR ->
+            MentorshipsTable.selectAll()
+                .where {
+                    (MentorshipsTable.mentorId eq facilitatorId) and
+                        MentorshipsTable.revokedAt.isNull() and
+                        (MentorshipsTable.menteeId eq subjectUserId)
+                }
+                .firstOrNull() != null
+
+        DatabaseUserRole.GUEST -> false
+    }
+}
+
+internal fun ensureEmployeeSelfSubject(
+    facilitatorId: UUID,
+    facilitatorRole: DatabaseUserRole,
+    subjectUserId: UUID,
+) {
+    if (facilitatorRole == DatabaseUserRole.EMPLOYEE && subjectUserId != facilitatorId) {
+        throw DatabaseException.Forbidden(
+            message = "Employees may only view their own learning progress",
+        )
+    }
+}

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/table/GuestSessionTable.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/table/GuestSessionTable.kt
@@ -1,0 +1,11 @@
+package dev.kigya.headway.database.internal.data.table
+
+import org.jetbrains.exposed.v1.core.dao.id.UUIDTable
+import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
+import java.time.OffsetDateTime
+
+internal object GuestSessionTable : UUIDTable(name = "public.guest_session") {
+    val createdAt = timestampWithTimeZone(name = "created_at")
+        .clientDefault { OffsetDateTime.now() }
+    val revokedAt = timestampWithTimeZone(name = "revoked_at").nullable()
+}

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/table/LearningQuestionPartialRemarkTable.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/table/LearningQuestionPartialRemarkTable.kt
@@ -1,0 +1,26 @@
+package dev.kigya.headway.database.internal.data.table
+
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.UUIDTable
+import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
+import java.time.OffsetDateTime
+
+internal object LearningQuestionPartialRemarkTable : UUIDTable(name = "public.learning_question_partial_remark") {
+    val subjectUserId = reference(
+        name = "subject_user_id",
+        foreign = UsersTable,
+        onDelete = ReferenceOption.CASCADE,
+    )
+    val questionId = long(name = "question_id").references(
+        ref = QuestionsTable.id,
+        onDelete = ReferenceOption.CASCADE,
+    )
+    val authorUserId = reference(
+        name = "author_user_id",
+        foreign = UsersTable,
+        onDelete = ReferenceOption.CASCADE,
+    )
+    val body = text(name = "body")
+    val createdAt = timestampWithTimeZone(name = "created_at")
+        .clientDefault { OffsetDateTime.now() }
+}

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/table/LearningQuestionProgressState.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/table/LearningQuestionProgressState.kt
@@ -1,0 +1,7 @@
+package dev.kigya.headway.database.internal.data.table
+
+internal enum class LearningQuestionProgressState {
+    NOT_ANSWERED,
+    PARTIALLY_ANSWERED,
+    ANSWERED,
+}

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/table/LearningQuestionProgressTable.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/table/LearningQuestionProgressTable.kt
@@ -1,0 +1,34 @@
+package dev.kigya.headway.database.internal.data.table
+
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
+import org.postgresql.util.PGobject
+import java.time.OffsetDateTime
+
+internal object LearningQuestionProgressTable : Table(name = "public.learning_question_progress") {
+    val subjectUserId = reference(
+        name = "subject_user_id",
+        foreign = UsersTable,
+        onDelete = ReferenceOption.CASCADE,
+    )
+    val questionId = long(name = "question_id").references(
+        ref = QuestionsTable.id,
+        onDelete = ReferenceOption.CASCADE,
+    )
+    val state = customEnumeration(
+        name = "state",
+        sql = "learning_question_progress_state",
+        fromDb = { raw -> LearningQuestionProgressState.valueOf(pgEnumRaw(raw)) },
+        toDb = { v ->
+            PGobject().apply {
+                type = "learning_question_progress_state"
+                value = v.name
+            }
+        },
+    )
+    val updatedAt = timestampWithTimeZone(name = "updated_at")
+        .clientDefault { OffsetDateTime.now() }
+
+    override val primaryKey = PrimaryKey(subjectUserId, questionId)
+}

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/di/DatabaseInternalModule.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/di/DatabaseInternalModule.kt
@@ -4,7 +4,11 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import dev.kigya.headway.database.internal.core.config.ConfigurationValues
 import dev.kigya.headway.database.internal.core.config.DatabaseConfig
+import dev.kigya.headway.database.internal.data.learning.LearningQuestionPreparationSync
+import dev.kigya.headway.database.internal.data.repository.GuestSessionsRepository
 import dev.kigya.headway.database.internal.data.repository.InterviewQuestionBankRepository
+import dev.kigya.headway.database.internal.data.repository.LearningQuestionRemarksRepository
+import dev.kigya.headway.database.internal.data.repository.LearningQuestionsReadRepository
 import dev.kigya.headway.database.internal.data.repository.PreparationRepository
 import dev.kigya.headway.database.internal.data.repository.RefreshSessionsRepository
 import dev.kigya.headway.database.internal.data.repository.UsersRepository
@@ -27,6 +31,7 @@ import dev.kigya.headway.database.internal.domain.usecase.StartPreparationSessio
 import dev.kigya.headway.database.internal.domain.usecase.SubmitPreparationOutcomeUseCase
 import dev.kigya.headway.database.internal.domain.usecase.UpsertGoogleUserUseCase
 import dev.kigya.headway.database.internal.domain.usecase.ValidateSessionUseCase
+import dev.kigya.headway.database.internal.presentation.LearningQuestionsService
 import dev.kigya.headway.database.internal.presentation.PreparationUseCases
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.koin.core.module.dsl.singleOf
@@ -52,7 +57,18 @@ internal val databaseModule = module {
     singleOf(::RefreshSessionsRepository) bind RefreshSessionsRepositoryContract::class
     singleOf(::InterviewQuestionBankRepository)
     singleOf(::BuildSessionQuestionSnapshotUseCase)
-    singleOf(::PreparationRepository) bind PreparationRepositoryContract::class
+    singleOf(::LearningQuestionPreparationSync)
+    singleOf(::LearningQuestionsReadRepository)
+    singleOf(::LearningQuestionRemarksRepository)
+    singleOf(::GuestSessionsRepository)
+    single {
+        PreparationRepository(
+            database = get(),
+            buildSessionQuestionSnapshot = get(),
+            learningQuestionPreparationSync = get(),
+        )
+    } bind PreparationRepositoryContract::class
+    singleOf(::LearningQuestionsService)
 
     singleOf(::GetGoogleUserUseCase)
     singleOf(::CreateGoogleUserUseCase)

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/presentation/DatabaseApplicationUseCases.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/presentation/DatabaseApplicationUseCases.kt
@@ -1,5 +1,6 @@
 package dev.kigya.headway.database.internal.presentation
 
+import dev.kigya.headway.database.internal.data.repository.GuestSessionsRepository
 import dev.kigya.headway.database.internal.domain.usecase.CreateGoogleUserUseCase
 import dev.kigya.headway.database.internal.domain.usecase.CreateSessionUseCase
 import dev.kigya.headway.database.internal.domain.usecase.GetGoogleUserUseCase
@@ -15,4 +16,6 @@ internal data class DatabaseApplicationUseCases(
     val createSession: CreateSessionUseCase,
     val validateSession: ValidateSessionUseCase,
     val preparation: PreparationUseCases,
+    val learningQuestions: LearningQuestionsService,
+    val guestSessions: GuestSessionsRepository,
 )

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/presentation/LearningQuestionsService.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/presentation/LearningQuestionsService.kt
@@ -1,0 +1,174 @@
+package dev.kigya.headway.database.internal.presentation
+
+import dev.kigya.headway.database.api.model.`in`.DatabaseLearningFacilitatedPageQuery
+import dev.kigya.headway.database.api.model.`in`.DatabaseLearningRemarkCreateRequestDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningCatalogResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningPageResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningQuestionDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningRemarkDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningSearchResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningSkillGroup
+import dev.kigya.headway.database.api.model.out.DatabaseUserRole
+import dev.kigya.headway.database.internal.data.repository.LearningQuestionRemarksRepository
+import dev.kigya.headway.database.internal.data.repository.LearningQuestionsReadRepository
+import dev.kigya.headway.database.internal.data.scope.ensureEmployeeSelfSubject
+import dev.kigya.headway.database.internal.data.scope.isSubjectInFacilitatorLearningScope
+import dev.kigya.headway.database.internal.domain.error.DatabaseException
+import java.util.UUID
+
+internal class LearningQuestionsService(
+    private val readRepository: LearningQuestionsReadRepository,
+    private val remarksRepository: LearningQuestionRemarksRepository,
+) {
+
+    suspend fun getPublicCatalog(locale: String): DatabaseLearningCatalogResponseDto =
+        readRepository.loadPublicCatalog(locale = locale)
+
+    suspend fun getCatalog(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        locale: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningCatalogResponseDto = readRepository.loadCatalog(
+        facilitatorUserId = facilitatorUserId,
+        facilitatorRole = facilitatorRole,
+        locale = locale,
+        subjectUserId = subjectUserId,
+    )
+
+    suspend fun getPublicPage(
+        locale: String,
+        skillGroup: DatabaseLearningSkillGroup,
+        limit: Int,
+        afterQuestionId: Long?,
+    ): DatabaseLearningPageResponseDto = readRepository.loadPublicPage(
+        locale = locale,
+        skillGroup = skillGroup,
+        limit = limit.coerceIn(LEARNING_PAGE_MIN, LEARNING_PAGE_MAX),
+        afterQuestionId = afterQuestionId,
+    )
+
+    suspend fun getPage(
+        query: DatabaseLearningFacilitatedPageQuery,
+    ): DatabaseLearningPageResponseDto = readRepository.loadPage(
+        query = query.copy(
+            limit = query.limit.coerceIn(LEARNING_PAGE_MIN, LEARNING_PAGE_MAX),
+        ),
+    )
+
+    suspend fun getPublicSearch(
+        locale: String,
+        query: String,
+    ): DatabaseLearningSearchResponseDto =
+        readRepository.loadPublicSearch(locale = locale, query = query)
+
+    suspend fun getSearch(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        locale: String,
+        query: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningSearchResponseDto = readRepository.loadSearch(
+        facilitatorUserId = facilitatorUserId,
+        facilitatorRole = facilitatorRole,
+        locale = locale,
+        query = query,
+        subjectUserId = subjectUserId,
+    )
+
+    suspend fun getPublicQuestion(
+        questionId: Long,
+        locale: String,
+    ): DatabaseLearningQuestionDto =
+        readRepository.loadPublicQuestionById(questionId = questionId, locale = locale)
+
+    suspend fun getQuestion(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        questionId: Long,
+        locale: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningQuestionDto = readRepository.loadQuestionById(
+        facilitatorUserId = facilitatorUserId,
+        facilitatorRole = facilitatorRole,
+        questionId = questionId,
+        locale = locale,
+        subjectUserId = subjectUserId,
+    )
+
+    suspend fun listRemarks(
+        questionId: Long,
+        subjectUserId: UUID,
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+    ): List<DatabaseLearningRemarkDto> {
+        resolveSubjectForRemarks(
+            facilitatorUserId = facilitatorUserId,
+            facilitatorRole = facilitatorRole,
+            subjectUserId = subjectUserId,
+        )
+        return remarksRepository.listRemarks(
+            questionId = questionId,
+            subjectUserId = subjectUserId,
+        )
+    }
+
+    suspend fun addRemark(
+        questionId: Long,
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        body: DatabaseLearningRemarkCreateRequestDto,
+    ): DatabaseLearningRemarkDto {
+        val subjectUserId = body.subjectUserId
+        resolveSubjectForRemarks(
+            facilitatorUserId = facilitatorUserId,
+            facilitatorRole = facilitatorRole,
+            subjectUserId = subjectUserId,
+        )
+        val trimmed = body.body.trim()
+        if (trimmed.isEmpty()) {
+            throw DatabaseException.InvalidRequest(
+                message = "Remark body is blank",
+            )
+        }
+        if (trimmed.length > REMARK_BODY_MAX_LENGTH) {
+            throw DatabaseException.InvalidRequest(
+                message = "Remark body exceeds maximum length",
+            )
+        }
+        return remarksRepository.insertRemark(
+            questionId = questionId,
+            subjectUserId = subjectUserId,
+            authorUserId = facilitatorUserId,
+            body = trimmed,
+        )
+    }
+}
+
+private fun resolveSubjectForRemarks(
+    facilitatorUserId: UUID,
+    facilitatorRole: DatabaseUserRole,
+    subjectUserId: UUID,
+) {
+    ensureEmployeeSelfSubject(
+        facilitatorId = facilitatorUserId,
+        facilitatorRole = facilitatorRole,
+        subjectUserId = subjectUserId,
+    )
+    if (!isSubjectInFacilitatorLearningScope(
+            facilitatorId = facilitatorUserId,
+            facilitatorRole = facilitatorRole,
+            subjectUserId = subjectUserId,
+        )
+    ) {
+        throw DatabaseException.Forbidden(
+            message = "Subject not in facilitator scope",
+        )
+    }
+}
+
+private const val LEARNING_PAGE_MIN: Int = 1
+
+private const val LEARNING_PAGE_MAX: Int = 100
+
+private const val REMARK_BODY_MAX_LENGTH: Int = 2000

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/presentation/plugin/DatabaseRouting.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/presentation/plugin/DatabaseRouting.kt
@@ -3,6 +3,8 @@ package dev.kigya.headway.database.internal.presentation.plugin
 import dev.kigya.headway.common.extension.healthzRouting
 import dev.kigya.headway.database.api.url.databaseServiceUrlHolder
 import dev.kigya.headway.database.internal.presentation.DatabaseApplicationUseCases
+import dev.kigya.headway.database.internal.presentation.routing.guestSessionsRouting
+import dev.kigya.headway.database.internal.presentation.routing.learningQuestionsRouting
 import dev.kigya.headway.database.internal.presentation.routing.preparationRouting
 import dev.kigya.headway.database.internal.presentation.routing.sessionRouting
 import dev.kigya.headway.database.internal.presentation.routing.usersRouting
@@ -28,6 +30,10 @@ internal fun Application.databaseRouting(useCases: DatabaseApplicationUseCases) 
             )
 
             preparationRouting(preparation = useCases.preparation)
+
+            learningQuestionsRouting(learning = useCases.learningQuestions)
+
+            guestSessionsRouting(guestSessions = useCases.guestSessions)
         }
     }
 }

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/presentation/routing/GuestSessionsRouting.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/presentation/routing/GuestSessionsRouting.kt
@@ -1,0 +1,29 @@
+package dev.kigya.headway.database.internal.presentation.routing
+
+import dev.kigya.headway.database.api.model.`in`.DatabaseGuestSessionRegisterRequestDto
+import dev.kigya.headway.database.api.model.resource.DatabaseResource
+import dev.kigya.headway.database.internal.data.repository.GuestSessionsRepository
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.receive
+import io.ktor.server.resources.get
+import io.ktor.server.resources.post
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+
+internal fun Route.guestSessionsRouting(guestSessions: GuestSessionsRepository) {
+    post<DatabaseResource.GuestSessions.Register> {
+        val body = call.receive<DatabaseGuestSessionRegisterRequestDto>()
+        guestSessions.register(sessionId = body.id)
+        call.respond(HttpStatusCode.Created)
+    }
+
+    post<DatabaseResource.GuestSessions.Revoke> { params ->
+        guestSessions.revoke(sessionId = params.sessionId)
+        call.respond(HttpStatusCode.NoContent)
+    }
+
+    get<DatabaseResource.GuestSessions.Validate> { params ->
+        guestSessions.ensureActive(sessionId = params.sessionId)
+        call.respond(HttpStatusCode.OK)
+    }
+}

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/presentation/routing/LearningRouting.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/presentation/routing/LearningRouting.kt
@@ -1,0 +1,145 @@
+package dev.kigya.headway.database.internal.presentation.routing
+
+import dev.kigya.headway.database.api.model.`in`.DatabaseLearningFacilitatedPageQuery
+import dev.kigya.headway.database.api.model.`in`.DatabaseLearningRemarkCreateRequestDto
+import dev.kigya.headway.database.api.model.resource.DatabaseResource
+import dev.kigya.headway.database.internal.presentation.LearningQuestionsService
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.request.receive
+import io.ktor.server.resources.get
+import io.ktor.server.resources.post
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+
+internal fun Route.learningQuestionsRouting(learning: LearningQuestionsService) {
+    registerLearningCatalogRoutes(learning)
+    registerLearningPageRoutes(learning)
+    registerLearningSearchRoutes(learning)
+    registerLearningQuestionByIdRoutes(learning)
+    registerLearningRemarks(learning)
+}
+
+private fun Route.registerLearningCatalogRoutes(learning: LearningQuestionsService) {
+    get<DatabaseResource.LearningQuestions.PublicCatalog> { params ->
+        val locale = requireNonBlankLearningLocale(params.locale)
+        call.respond(learning.getPublicCatalog(locale = locale))
+    }
+
+    get<DatabaseResource.LearningQuestions.Catalog> { params ->
+        val locale = requireNonBlankLearningLocale(params.locale)
+        call.respond(
+            learning.getCatalog(
+                facilitatorUserId = params.facilitatorUserId,
+                facilitatorRole = params.facilitatorRole,
+                locale = locale,
+                subjectUserId = params.subjectUserId,
+            ),
+        )
+    }
+}
+
+private fun Route.registerLearningPageRoutes(learning: LearningQuestionsService) {
+    get<DatabaseResource.LearningQuestions.PublicPage> { params ->
+        val locale = requireNonBlankLearningLocale(params.locale)
+        call.respond(
+            learning.getPublicPage(
+                locale = locale,
+                skillGroup = params.skillGroup,
+                limit = params.limit,
+                afterQuestionId = params.afterQuestionId,
+            ),
+        )
+    }
+
+    get<DatabaseResource.LearningQuestions.Page> { params ->
+        val locale = requireNonBlankLearningLocale(params.locale)
+        call.respond(
+            learning.getPage(
+                query = DatabaseLearningFacilitatedPageQuery(
+                    facilitatorUserId = params.facilitatorUserId,
+                    facilitatorRole = params.facilitatorRole,
+                    locale = locale,
+                    skillGroup = params.skillGroup,
+                    limit = params.limit,
+                    afterQuestionId = params.afterQuestionId,
+                    subjectUserId = params.subjectUserId,
+                ),
+            ),
+        )
+    }
+}
+
+private fun Route.registerLearningSearchRoutes(learning: LearningQuestionsService) {
+    get<DatabaseResource.LearningQuestions.PublicSearch> { params ->
+        val locale = requireNonBlankLearningLocale(params.locale)
+        call.respond(learning.getPublicSearch(locale = locale, query = params.q))
+    }
+
+    get<DatabaseResource.LearningQuestions.Search> { params ->
+        val locale = requireNonBlankLearningLocale(params.locale)
+        call.respond(
+            learning.getSearch(
+                facilitatorUserId = params.facilitatorUserId,
+                facilitatorRole = params.facilitatorRole,
+                locale = locale,
+                query = params.q,
+                subjectUserId = params.subjectUserId,
+            ),
+        )
+    }
+}
+
+private fun Route.registerLearningQuestionByIdRoutes(learning: LearningQuestionsService) {
+    get<DatabaseResource.LearningQuestions.PublicById> { params ->
+        val locale = requireNonBlankLearningLocale(params.locale)
+        call.respond(learning.getPublicQuestion(questionId = params.questionId, locale = locale))
+    }
+
+    get<DatabaseResource.LearningQuestions.ById> { params ->
+        val locale = requireNonBlankLearningLocale(params.locale)
+        call.respond(
+            learning.getQuestion(
+                facilitatorUserId = params.facilitatorUserId,
+                facilitatorRole = params.facilitatorRole,
+                questionId = params.questionId,
+                locale = locale,
+                subjectUserId = params.subjectUserId,
+            ),
+        )
+    }
+}
+
+private fun Route.registerLearningRemarks(learning: LearningQuestionsService) {
+    get<DatabaseResource.LearningQuestions.Remarks> { params ->
+        call.respond(
+            learning.listRemarks(
+                questionId = params.questionId,
+                subjectUserId = params.subjectUserId,
+                facilitatorUserId = params.facilitatorUserId,
+                facilitatorRole = params.facilitatorRole,
+            ),
+        )
+    }
+
+    post<DatabaseResource.LearningQuestions.Remarks> { params ->
+        val body = call.receive<DatabaseLearningRemarkCreateRequestDto>()
+        call.respond(
+            learning.addRemark(
+                questionId = params.questionId,
+                facilitatorUserId = params.facilitatorUserId,
+                facilitatorRole = params.facilitatorRole,
+                body = body,
+            ),
+        )
+    }
+}
+
+private fun requireNonBlankLearningLocale(raw: String): String {
+    val trimmed = raw.trim()
+    if (trimmed.isBlank()) {
+        throw BadRequestException(LEARNING_LOCALE_BLANK_MESSAGE)
+    }
+    return trimmed
+}
+
+private const val LEARNING_LOCALE_BLANK_MESSAGE: String = "Locale is blank"

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/GatewayApplication.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/GatewayApplication.kt
@@ -3,6 +3,7 @@ package dev.kigya.headway.gateway
 import dev.kigya.headway.common.config.CommonConfigurationValues
 import dev.kigya.headway.gateway.core.config.ConfigurationValues
 import dev.kigya.headway.gateway.di.gatewayDependencies
+import dev.kigya.headway.gateway.domain.usecase.LearningQuestionsGraphqlUseCases
 import dev.kigya.headway.gateway.presentation.GatewayApiBindings
 import dev.kigya.headway.gateway.presentation.installGatewayApi
 import dev.kigya.headway.gateway.presentation.schema.PreparationGraphqlServices
@@ -47,6 +48,7 @@ private fun Application.gatewayApp() {
                 finishPreparationSession = get(),
                 getPreparationSessionSummary = get(),
             ),
+            learningQuestions = get<LearningQuestionsGraphqlUseCases>(),
         ),
     )
 }

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/data/repository/LearningQuestionsRepository.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/data/repository/LearningQuestionsRepository.kt
@@ -1,0 +1,222 @@
+package dev.kigya.headway.gateway.data.repository
+
+import dev.kigya.headway.database.api.model.`in`.DatabaseLearningFacilitatedPageQuery
+import dev.kigya.headway.database.api.model.`in`.DatabaseLearningRemarkCreateRequestDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningCatalogResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningPageResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningQuestionDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningRemarkDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningSearchResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningSkillGroup
+import dev.kigya.headway.database.api.model.out.DatabaseUserRole
+import dev.kigya.headway.database.api.model.resource.DatabaseResource
+import dev.kigya.headway.gateway.core.http.upstreamCall
+import dev.kigya.headway.gateway.domain.repository.LearningQuestionsRepositoryContract
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.resources.get
+import io.ktor.client.plugins.resources.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import java.util.UUID
+
+internal class LearningQuestionsRepository(
+    private val httpClient: HttpClient,
+) : LearningQuestionsRepositoryContract {
+
+    override suspend fun getPublicCatalog(locale: String): DatabaseLearningCatalogResponseDto =
+        upstreamCall(
+            dependency = DATABASE_UPSTREAM,
+            request = {
+                httpClient.get(DatabaseResource.LearningQuestions.PublicCatalog(locale = locale))
+            },
+            onSuccess = { it.body<DatabaseLearningCatalogResponseDto>() },
+        )
+
+    override suspend fun getCatalog(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        locale: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningCatalogResponseDto = upstreamCall(
+        dependency = DATABASE_UPSTREAM,
+        request = {
+            httpClient.get(
+                DatabaseResource.LearningQuestions.Catalog(
+                    locale = locale,
+                    facilitatorUserId = facilitatorUserId,
+                    facilitatorRole = facilitatorRole,
+                    subjectUserId = subjectUserId,
+                ),
+            )
+        },
+        onSuccess = { it.body<DatabaseLearningCatalogResponseDto>() },
+    )
+
+    override suspend fun getPublicPage(
+        locale: String,
+        skillGroup: DatabaseLearningSkillGroup,
+        limit: Int,
+        afterQuestionId: Long?,
+    ): DatabaseLearningPageResponseDto = upstreamCall(
+        dependency = DATABASE_UPSTREAM,
+        request = {
+            httpClient.get(
+                DatabaseResource.LearningQuestions.PublicPage(
+                    locale = locale,
+                    skillGroup = skillGroup,
+                    limit = limit,
+                    afterQuestionId = afterQuestionId,
+                ),
+            )
+        },
+        onSuccess = { it.body<DatabaseLearningPageResponseDto>() },
+    )
+
+    override suspend fun getPage(
+        query: DatabaseLearningFacilitatedPageQuery,
+    ): DatabaseLearningPageResponseDto = upstreamCall(
+        dependency = DATABASE_UPSTREAM,
+        request = {
+            httpClient.get(
+                DatabaseResource.LearningQuestions.Page(
+                    locale = query.locale,
+                    skillGroup = query.skillGroup,
+                    limit = query.limit,
+                    afterQuestionId = query.afterQuestionId,
+                    facilitatorUserId = query.facilitatorUserId,
+                    facilitatorRole = query.facilitatorRole,
+                    subjectUserId = query.subjectUserId,
+                ),
+            )
+        },
+        onSuccess = { it.body<DatabaseLearningPageResponseDto>() },
+    )
+
+    override suspend fun getPublicSearch(
+        locale: String,
+        query: String,
+    ): DatabaseLearningSearchResponseDto = upstreamCall(
+        dependency = DATABASE_UPSTREAM,
+        request = {
+            httpClient.get(
+                DatabaseResource.LearningQuestions.PublicSearch(locale = locale, q = query),
+            )
+        },
+        onSuccess = { it.body<DatabaseLearningSearchResponseDto>() },
+    )
+
+    override suspend fun getSearch(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        locale: String,
+        query: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningSearchResponseDto = upstreamCall(
+        dependency = DATABASE_UPSTREAM,
+        request = {
+            httpClient.get(
+                DatabaseResource.LearningQuestions.Search(
+                    locale = locale,
+                    q = query,
+                    facilitatorUserId = facilitatorUserId,
+                    facilitatorRole = facilitatorRole,
+                    subjectUserId = subjectUserId,
+                ),
+            )
+        },
+        onSuccess = { it.body<DatabaseLearningSearchResponseDto>() },
+    )
+
+    override suspend fun getPublicQuestion(
+        questionId: Long,
+        locale: String,
+    ): DatabaseLearningQuestionDto = upstreamCall(
+        dependency = DATABASE_UPSTREAM,
+        request = {
+            httpClient.get(
+                DatabaseResource.LearningQuestions.PublicById(
+                    questionId = questionId,
+                    locale = locale,
+                ),
+            )
+        },
+        onSuccess = { it.body<DatabaseLearningQuestionDto>() },
+    )
+
+    override suspend fun getQuestion(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        questionId: Long,
+        locale: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningQuestionDto = upstreamCall(
+        dependency = DATABASE_UPSTREAM,
+        request = {
+            httpClient.get(
+                DatabaseResource.LearningQuestions.ById(
+                    questionId = questionId,
+                    locale = locale,
+                    facilitatorUserId = facilitatorUserId,
+                    facilitatorRole = facilitatorRole,
+                    subjectUserId = subjectUserId,
+                ),
+            )
+        },
+        onSuccess = { it.body<DatabaseLearningQuestionDto>() },
+    )
+
+    override suspend fun listRemarks(
+        questionId: Long,
+        subjectUserId: UUID,
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+    ): List<DatabaseLearningRemarkDto> = upstreamCall(
+        dependency = DATABASE_UPSTREAM,
+        request = {
+            httpClient.get(
+                DatabaseResource.LearningQuestions.Remarks(
+                    questionId = questionId,
+                    subjectUserId = subjectUserId,
+                    facilitatorUserId = facilitatorUserId,
+                    facilitatorRole = facilitatorRole,
+                ),
+            )
+        },
+        onSuccess = { it.body<List<DatabaseLearningRemarkDto>>() },
+    )
+
+    override suspend fun addRemark(
+        questionId: Long,
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        body: DatabaseLearningRemarkCreateRequestDto,
+    ): DatabaseLearningRemarkDto = upstreamCall(
+        dependency = DATABASE_UPSTREAM,
+        request = {
+            httpClient.post(
+                DatabaseResource.LearningQuestions.Remarks(
+                    questionId = questionId,
+                    subjectUserId = body.subjectUserId,
+                    facilitatorUserId = facilitatorUserId,
+                    facilitatorRole = facilitatorRole,
+                ),
+            ) {
+                contentType(ContentType.Application.Json)
+                setBody(body)
+            }
+        },
+        onSuccess = { it.body<DatabaseLearningRemarkDto>() },
+    )
+
+    override suspend fun revokeGuestSession(sessionId: UUID) = upstreamCall(
+        dependency = DATABASE_UPSTREAM,
+        request = {
+            httpClient.post(DatabaseResource.GuestSessions.Revoke(sessionId = sessionId))
+        },
+        onSuccess = { },
+    )
+}
+
+private const val DATABASE_UPSTREAM: String = "database"

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/di/inner/DatabaseDependencies.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/di/inner/DatabaseDependencies.kt
@@ -2,8 +2,10 @@ package dev.kigya.headway.gateway.di.inner
 
 import dev.kigya.headway.database.api.url.DatabaseKoinHttpClient
 import dev.kigya.headway.gateway.data.repository.DatabaseRepository
+import dev.kigya.headway.gateway.data.repository.LearningQuestionsRepository
 import dev.kigya.headway.gateway.data.repository.PreparationRepository
 import dev.kigya.headway.gateway.domain.repository.DatabaseRepositoryContract
+import dev.kigya.headway.gateway.domain.repository.LearningQuestionsRepositoryContract
 import dev.kigya.headway.gateway.domain.repository.PreparationRepositoryContract
 import dev.kigya.headway.gateway.domain.usecase.FinishPreparationSessionUseCase
 import dev.kigya.headway.gateway.domain.usecase.GetPreparationEmployeeReadinessUseCase
@@ -12,6 +14,7 @@ import dev.kigya.headway.gateway.domain.usecase.GetPreparationSessionStateUseCas
 import dev.kigya.headway.gateway.domain.usecase.GetPreparationSessionSummaryUseCase
 import dev.kigya.headway.gateway.domain.usecase.GetPreparationSetupEmployeesUseCase
 import dev.kigya.headway.gateway.domain.usecase.InviteUserUseCase
+import dev.kigya.headway.gateway.domain.usecase.LearningQuestionsGraphqlUseCases
 import dev.kigya.headway.gateway.domain.usecase.SelectPreparationSessionQuestionUseCase
 import dev.kigya.headway.gateway.domain.usecase.StartPreparationSessionUseCase
 import dev.kigya.headway.gateway.domain.usecase.SubmitPreparationOutcomeUseCase
@@ -28,6 +31,12 @@ internal fun Module.databaseDependencies() {
     single {
         PreparationRepository(httpClient = get(named<DatabaseKoinHttpClient>()))
     } bind PreparationRepositoryContract::class
+
+    single {
+        LearningQuestionsRepository(httpClient = get(named<DatabaseKoinHttpClient>()))
+    } bind LearningQuestionsRepositoryContract::class
+
+    singleOf(::LearningQuestionsGraphqlUseCases)
 
     singleOf(::InviteUserUseCase)
     singleOf(::GetPreparationSetupEmployeesUseCase)

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/domain/auth/GatewayAuthorizationPolicy.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/domain/auth/GatewayAuthorizationPolicy.kt
@@ -16,6 +16,9 @@ internal object GatewayAuthorizationPolicy {
             GatewayOperation.InviteUser -> ensureInviteUser(principal)
             GatewayOperation.HomeScreen -> ensureHomeScreen(principal)
             GatewayOperation.Preparation -> ensurePreparation(principal)
+            GatewayOperation.LearningRead -> ensureLearningRead(principal)
+            GatewayOperation.LearningRemarkWrite -> ensureLearningRemarkWrite(principal)
+            GatewayOperation.LogoutGuest -> ensureLogoutGuest(principal)
         }
     }
 
@@ -49,6 +52,59 @@ internal object GatewayAuthorizationPolicy {
         }
     }
 
+    private fun ensureLearningRead(principal: GatewayPrincipal) {
+        when (principal) {
+            is GatewayPrincipal.Guest ->
+                if (!principal.scopes.contains(GUEST_LEARN_SCOPE)) {
+                    throw GatewayException.Forbidden(
+                        reason = GatewayErrorReason.GUEST_NOT_ALLOWED,
+                        message = "Guest scope does not allow learning reads",
+                    )
+                }
+
+            is GatewayPrincipal.User -> Unit
+        }
+    }
+
+    private fun ensureLearningRemarkWrite(principal: GatewayPrincipal) {
+        when (principal) {
+            is GatewayPrincipal.Guest -> throw GatewayException.Forbidden(
+                reason = GatewayErrorReason.GUEST_NOT_ALLOWED,
+                message = "Guests cannot author learning remarks",
+            )
+
+            is GatewayPrincipal.User -> {
+                val role = principal.user.role
+                if (role != GatewayUserRole.MENTOR &&
+                    role != GatewayUserRole.DEVELOPER &&
+                    role != GatewayUserRole.MANAGER
+                ) {
+                    throw GatewayException.Forbidden(
+                        reason = GatewayErrorReason.INSUFFICIENT_ROLE,
+                        message = "Insufficient role to author learning remarks",
+                    )
+                }
+            }
+        }
+    }
+
+    private fun ensureLogoutGuest(principal: GatewayPrincipal) {
+        when (principal) {
+            is GatewayPrincipal.Guest ->
+                if (!principal.scopes.contains(GUEST_LEARN_SCOPE)) {
+                    throw GatewayException.Forbidden(
+                        reason = GatewayErrorReason.GUEST_NOT_ALLOWED,
+                        message = "Guest scope does not allow logout",
+                    )
+                }
+
+            is GatewayPrincipal.User -> throw GatewayException.Forbidden(
+                reason = GatewayErrorReason.INSUFFICIENT_ROLE,
+                message = "Only guest sessions may call logoutGuest",
+            )
+        }
+    }
+
     private fun ensureInviteUser(principal: GatewayPrincipal) {
         when (principal) {
             is GatewayPrincipal.Guest -> throw GatewayException.Forbidden(
@@ -68,3 +124,5 @@ internal object GatewayAuthorizationPolicy {
         }
     }
 }
+
+private const val GUEST_LEARN_SCOPE: String = "learn_guest"

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/domain/auth/GatewayOperation.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/domain/auth/GatewayOperation.kt
@@ -5,4 +5,7 @@ internal enum class GatewayOperation {
     InviteUser,
     HomeScreen,
     Preparation,
+    LearningRead,
+    LearningRemarkWrite,
+    LogoutGuest,
 }

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/domain/repository/LearningGuestSessionRevocationContract.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/domain/repository/LearningGuestSessionRevocationContract.kt
@@ -1,0 +1,7 @@
+package dev.kigya.headway.gateway.domain.repository
+
+import java.util.UUID
+
+internal interface LearningGuestSessionRevocationContract {
+    suspend fun revokeGuestSession(sessionId: UUID)
+}

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/domain/repository/LearningQuestionsRepositoryContract.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/domain/repository/LearningQuestionsRepositoryContract.kt
@@ -1,0 +1,75 @@
+package dev.kigya.headway.gateway.domain.repository
+
+import dev.kigya.headway.database.api.model.`in`.DatabaseLearningFacilitatedPageQuery
+import dev.kigya.headway.database.api.model.`in`.DatabaseLearningRemarkCreateRequestDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningCatalogResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningPageResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningQuestionDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningRemarkDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningSearchResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningSkillGroup
+import dev.kigya.headway.database.api.model.out.DatabaseUserRole
+import java.util.UUID
+
+internal interface LearningQuestionsRepositoryContract : LearningGuestSessionRevocationContract {
+
+    suspend fun getPublicCatalog(locale: String): DatabaseLearningCatalogResponseDto
+
+    suspend fun getCatalog(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        locale: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningCatalogResponseDto
+
+    suspend fun getPublicPage(
+        locale: String,
+        skillGroup: DatabaseLearningSkillGroup,
+        limit: Int,
+        afterQuestionId: Long?,
+    ): DatabaseLearningPageResponseDto
+
+    suspend fun getPage(
+        query: DatabaseLearningFacilitatedPageQuery,
+    ): DatabaseLearningPageResponseDto
+
+    suspend fun getPublicSearch(
+        locale: String,
+        query: String,
+    ): DatabaseLearningSearchResponseDto
+
+    suspend fun getSearch(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        locale: String,
+        query: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningSearchResponseDto
+
+    suspend fun getPublicQuestion(
+        questionId: Long,
+        locale: String,
+    ): DatabaseLearningQuestionDto
+
+    suspend fun getQuestion(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        questionId: Long,
+        locale: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningQuestionDto
+
+    suspend fun listRemarks(
+        questionId: Long,
+        subjectUserId: UUID,
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+    ): List<DatabaseLearningRemarkDto>
+
+    suspend fun addRemark(
+        questionId: Long,
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        body: DatabaseLearningRemarkCreateRequestDto,
+    ): DatabaseLearningRemarkDto
+}

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/domain/usecase/LearningQuestionsGraphqlUseCases.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/domain/usecase/LearningQuestionsGraphqlUseCases.kt
@@ -1,0 +1,167 @@
+package dev.kigya.headway.gateway.domain.usecase
+
+import dev.kigya.headway.database.api.model.`in`.DatabaseLearningFacilitatedPageQuery
+import dev.kigya.headway.database.api.model.`in`.DatabaseLearningRemarkCreateRequestDto
+import dev.kigya.headway.gateway.domain.repository.LearningQuestionsRepositoryContract
+import dev.kigya.headway.gateway.graphql.GatewayAppLocale
+import dev.kigya.headway.gateway.mapping.toDatabase
+import dev.kigya.headway.gateway.mapping.toGateway
+import dev.kigya.headway.gateway.mapping.toLearningLocaleWire
+import dev.kigya.headway.gateway.model.GatewayLearningQuestion
+import dev.kigya.headway.gateway.model.GatewayLearningQuestionRemark
+import dev.kigya.headway.gateway.model.GatewayLearningQuestionsCatalog
+import dev.kigya.headway.gateway.model.GatewayLearningQuestionsPage
+import dev.kigya.headway.gateway.model.GatewayLearningQuestionsSearchResult
+import dev.kigya.headway.gateway.model.GatewayLearningSkillGroup
+import dev.kigya.headway.gateway.model.GatewayPrincipal
+import dev.kigya.headway.gateway.model.GatewayUser
+import java.util.UUID
+
+internal class LearningQuestionsGraphqlUseCases(
+    private val repository: LearningQuestionsRepositoryContract,
+) {
+
+    suspend fun learningQuestionsCatalog(
+        principal: GatewayPrincipal,
+        locale: GatewayAppLocale,
+        subjectUserId: UUID?,
+    ): GatewayLearningQuestionsCatalog {
+        val wireLocale = locale.toLearningLocaleWire()
+        val stripProgress = principal is GatewayPrincipal.Guest
+        val dto = when (principal) {
+            is GatewayPrincipal.Guest ->
+                repository.getPublicCatalog(locale = wireLocale)
+
+            is GatewayPrincipal.User -> {
+                val user = principal.user
+                repository.getCatalog(
+                    facilitatorUserId = user.id,
+                    facilitatorRole = user.role.toDatabase(),
+                    locale = wireLocale,
+                    subjectUserId = subjectUserId ?: user.id,
+                )
+            }
+        }
+        return dto.toGateway(stripProgress = stripProgress)
+    }
+
+    suspend fun learningQuestionsPage(
+        principal: GatewayPrincipal,
+        locale: GatewayAppLocale,
+        skillGroup: GatewayLearningSkillGroup,
+        limit: Int,
+        afterQuestionId: Long?,
+        subjectUserId: UUID?,
+    ): GatewayLearningQuestionsPage {
+        val wireLocale = locale.toLearningLocaleWire()
+        val stripProgress = principal is GatewayPrincipal.Guest
+        val skill = skillGroup.toDatabase()
+        val dto = when (principal) {
+            is GatewayPrincipal.Guest ->
+                repository.getPublicPage(
+                    locale = wireLocale,
+                    skillGroup = skill,
+                    limit = limit,
+                    afterQuestionId = afterQuestionId,
+                )
+
+            is GatewayPrincipal.User -> {
+                val user = principal.user
+                repository.getPage(
+                    query = DatabaseLearningFacilitatedPageQuery(
+                        facilitatorUserId = user.id,
+                        facilitatorRole = user.role.toDatabase(),
+                        locale = wireLocale,
+                        skillGroup = skill,
+                        limit = limit,
+                        afterQuestionId = afterQuestionId,
+                        subjectUserId = subjectUserId ?: user.id,
+                    ),
+                )
+            }
+        }
+        return dto.toGateway(stripProgress = stripProgress)
+    }
+
+    suspend fun learningQuestionsSearch(
+        principal: GatewayPrincipal,
+        locale: GatewayAppLocale,
+        query: String,
+        subjectUserId: UUID?,
+    ): GatewayLearningQuestionsSearchResult {
+        val wireLocale = locale.toLearningLocaleWire()
+        val stripProgress = principal is GatewayPrincipal.Guest
+        val dto = when (principal) {
+            is GatewayPrincipal.Guest ->
+                repository.getPublicSearch(locale = wireLocale, query = query)
+
+            is GatewayPrincipal.User -> {
+                val user = principal.user
+                repository.getSearch(
+                    facilitatorUserId = user.id,
+                    facilitatorRole = user.role.toDatabase(),
+                    locale = wireLocale,
+                    query = query,
+                    subjectUserId = subjectUserId ?: user.id,
+                )
+            }
+        }
+        return dto.toGateway(stripProgress = stripProgress)
+    }
+
+    suspend fun learningQuestion(
+        principal: GatewayPrincipal,
+        locale: GatewayAppLocale,
+        questionId: Long,
+        subjectUserId: UUID?,
+    ): GatewayLearningQuestion {
+        val wireLocale = locale.toLearningLocaleWire()
+        val stripProgress = principal is GatewayPrincipal.Guest
+        val dto = when (principal) {
+            is GatewayPrincipal.Guest ->
+                repository.getPublicQuestion(questionId = questionId, locale = wireLocale)
+
+            is GatewayPrincipal.User -> {
+                val user = principal.user
+                repository.getQuestion(
+                    facilitatorUserId = user.id,
+                    facilitatorRole = user.role.toDatabase(),
+                    questionId = questionId,
+                    locale = wireLocale,
+                    subjectUserId = subjectUserId ?: user.id,
+                )
+            }
+        }
+        return dto.toGateway(stripProgress = stripProgress)
+    }
+
+    suspend fun learningQuestionRemarks(
+        user: GatewayUser,
+        questionId: Long,
+        subjectUserId: UUID,
+    ): List<GatewayLearningQuestionRemark> = repository.listRemarks(
+        questionId = questionId,
+        subjectUserId = subjectUserId,
+        facilitatorUserId = user.id,
+        facilitatorRole = user.role.toDatabase(),
+    ).map { it.toGateway() }
+
+    suspend fun addLearningQuestionRemark(
+        user: GatewayUser,
+        questionId: Long,
+        subjectUserId: UUID,
+        body: String,
+    ): GatewayLearningQuestionRemark = repository.addRemark(
+        questionId = questionId,
+        facilitatorUserId = user.id,
+        facilitatorRole = user.role.toDatabase(),
+        body = DatabaseLearningRemarkCreateRequestDto(
+            subjectUserId = subjectUserId,
+            body = body,
+        ),
+    ).toGateway()
+
+    suspend fun logoutGuest(sessionId: UUID) {
+        repository.revokeGuestSession(sessionId = sessionId)
+    }
+}

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/mapping/LearningQuestionsMappers.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/mapping/LearningQuestionsMappers.kt
@@ -1,0 +1,85 @@
+package dev.kigya.headway.gateway.mapping
+
+import dev.kigya.headway.database.api.model.out.DatabaseLearningCatalogResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningPageResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningProgressState
+import dev.kigya.headway.database.api.model.out.DatabaseLearningQuestionDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningRemarkDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningSearchResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningSkillGroup
+import dev.kigya.headway.database.api.model.out.DatabaseLearningTagDto
+import dev.kigya.headway.gateway.graphql.GatewayAppLocale
+import dev.kigya.headway.gateway.model.GatewayLearningProgressState
+import dev.kigya.headway.gateway.model.GatewayLearningQuestion
+import dev.kigya.headway.gateway.model.GatewayLearningQuestionRemark
+import dev.kigya.headway.gateway.model.GatewayLearningQuestionsCatalog
+import dev.kigya.headway.gateway.model.GatewayLearningQuestionsPage
+import dev.kigya.headway.gateway.model.GatewayLearningQuestionsSearchResult
+import dev.kigya.headway.gateway.model.GatewayLearningSkillGroup
+import dev.kigya.headway.gateway.model.GatewayLearningTag
+
+internal fun GatewayAppLocale.toLearningLocaleWire(): String = when (this) {
+    GatewayAppLocale.EN -> "en"
+    GatewayAppLocale.RU -> "ru"
+}
+
+internal fun DatabaseLearningCatalogResponseDto.toGateway(
+    stripProgress: Boolean,
+): GatewayLearningQuestionsCatalog = GatewayLearningQuestionsCatalog(
+    hardSkills = hardSkills.map { it.toGateway(stripProgress = stripProgress) },
+    softSkills = softSkills.map { it.toGateway(stripProgress = stripProgress) },
+    resumeHard = if (stripProgress) null else resumeHard,
+    resumeSoft = if (stripProgress) null else resumeSoft,
+)
+
+internal fun DatabaseLearningPageResponseDto.toGateway(
+    stripProgress: Boolean,
+): GatewayLearningQuestionsPage = GatewayLearningQuestionsPage(
+    items = items.map { it.toGateway(stripProgress = stripProgress) },
+    resumeHard = if (stripProgress) null else resumeHard,
+    resumeSoft = if (stripProgress) null else resumeSoft,
+)
+
+internal fun DatabaseLearningSearchResponseDto.toGateway(
+    stripProgress: Boolean,
+): GatewayLearningQuestionsSearchResult = GatewayLearningQuestionsSearchResult(
+    hardSkills = hardSkills.map { it.toGateway(stripProgress = stripProgress) },
+    softSkills = softSkills.map { it.toGateway(stripProgress = stripProgress) },
+)
+
+internal fun DatabaseLearningQuestionDto.toGateway(
+    stripProgress: Boolean,
+): GatewayLearningQuestion = GatewayLearningQuestion(
+    id = id,
+    skillGroup = skillGroup.toGateway(),
+    text = text,
+    tags = tags.map { it.toGateway() },
+    progress = if (stripProgress) null else progress?.toGateway(),
+)
+
+internal fun DatabaseLearningTagDto.toGateway(): GatewayLearningTag =
+    GatewayLearningTag(id = id, label = label)
+
+internal fun DatabaseLearningSkillGroup.toGateway(): GatewayLearningSkillGroup = when (this) {
+    DatabaseLearningSkillGroup.HARD -> GatewayLearningSkillGroup.HARD
+    DatabaseLearningSkillGroup.SOFT -> GatewayLearningSkillGroup.SOFT
+}
+
+internal fun DatabaseLearningProgressState.toGateway(): GatewayLearningProgressState = when (this) {
+    DatabaseLearningProgressState.NOT_ANSWERED -> GatewayLearningProgressState.NOT_ANSWERED
+    DatabaseLearningProgressState.PARTIALLY_ANSWERED -> GatewayLearningProgressState.PARTIALLY_ANSWERED
+    DatabaseLearningProgressState.ANSWERED -> GatewayLearningProgressState.ANSWERED
+}
+
+internal fun GatewayLearningSkillGroup.toDatabase(): DatabaseLearningSkillGroup = when (this) {
+    GatewayLearningSkillGroup.HARD -> DatabaseLearningSkillGroup.HARD
+    GatewayLearningSkillGroup.SOFT -> DatabaseLearningSkillGroup.SOFT
+}
+
+internal fun DatabaseLearningRemarkDto.toGateway(): GatewayLearningQuestionRemark =
+    GatewayLearningQuestionRemark(
+        id = id,
+        authorUserId = authorUserId,
+        body = body,
+        createdAtEpochMillis = createdAtEpochMillis,
+    )

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/model/LearningModels.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/model/LearningModels.kt
@@ -1,0 +1,93 @@
+package dev.kigya.headway.gateway.model
+
+import dev.kigya.headway.common.serialization.UUIDSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.util.UUID
+
+@Serializable
+internal enum class GatewayLearningSkillGroup {
+    @SerialName("HARD")
+    HARD,
+
+    @SerialName("SOFT")
+    SOFT,
+}
+
+@Serializable
+internal enum class GatewayLearningProgressState {
+    @SerialName("NOT_ANSWERED")
+    NOT_ANSWERED,
+
+    @SerialName("PARTIALLY_ANSWERED")
+    PARTIALLY_ANSWERED,
+
+    @SerialName("ANSWERED")
+    ANSWERED,
+}
+
+@Serializable
+internal data class GatewayLearningTag(
+    @SerialName("id")
+    val id: Long,
+    @SerialName("label")
+    val label: String,
+)
+
+@Serializable
+internal data class GatewayLearningQuestion(
+    @SerialName("id")
+    val id: Long,
+    @SerialName("skillGroup")
+    val skillGroup: GatewayLearningSkillGroup,
+    @SerialName("text")
+    val text: String,
+    @SerialName("tags")
+    val tags: List<GatewayLearningTag>,
+    @SerialName("progress")
+    val progress: GatewayLearningProgressState?,
+)
+
+@Serializable
+internal data class GatewayLearningQuestionsCatalog(
+    @SerialName("hardSkills")
+    val hardSkills: List<GatewayLearningQuestion>,
+    @SerialName("softSkills")
+    val softSkills: List<GatewayLearningQuestion>,
+    @SerialName("resumeHard")
+    val resumeHard: Long?,
+    @SerialName("resumeSoft")
+    val resumeSoft: Long?,
+)
+
+@Serializable
+internal data class GatewayLearningQuestionsPage(
+    @SerialName("items")
+    val items: List<GatewayLearningQuestion>,
+    @SerialName("resumeHard")
+    val resumeHard: Long?,
+    @SerialName("resumeSoft")
+    val resumeSoft: Long?,
+)
+
+@Serializable
+internal data class GatewayLearningQuestionsSearchResult(
+    @SerialName("hardSkills")
+    val hardSkills: List<GatewayLearningQuestion>,
+    @SerialName("softSkills")
+    val softSkills: List<GatewayLearningQuestion>,
+)
+
+@Serializable
+internal data class GatewayLearningQuestionRemark(
+    @SerialName("id")
+    @Serializable(UUIDSerializer::class)
+    val id: UUID,
+    @SerialName("authorUserId")
+    @Serializable(UUIDSerializer::class)
+    val authorUserId: UUID,
+    @SerialName("body")
+    val body: String,
+    @SerialName("createdAtEpochMillis")
+    val createdAtEpochMillis: Long,
+)

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/presentation/GatewayApi.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/presentation/GatewayApi.kt
@@ -19,6 +19,7 @@ import dev.kigya.headway.gateway.presentation.schema.authSchema
 import dev.kigya.headway.gateway.presentation.schema.databaseSchema
 import dev.kigya.headway.gateway.presentation.schema.healthSchema
 import dev.kigya.headway.gateway.presentation.schema.homeSchema
+import dev.kigya.headway.gateway.presentation.schema.learningQuestionsSchema
 import dev.kigya.headway.gateway.presentation.schema.preparationSchema
 import io.ktor.http.HttpHeaders
 import io.ktor.server.application.Application
@@ -91,6 +92,10 @@ internal fun Application.installGatewayApi(bindings: GatewayApiBindings) {
             preparationSchema(
                 resolvePrincipal = bindings.resolvePrincipal,
                 preparation = bindings.preparation,
+            )
+            learningQuestionsSchema(
+                resolvePrincipal = bindings.resolvePrincipal,
+                learningQuestions = bindings.learningQuestions,
             )
         }
     }

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/presentation/GatewayApiBindings.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/presentation/GatewayApiBindings.kt
@@ -6,6 +6,7 @@ import dev.kigya.headway.common.util.Environment
 import dev.kigya.headway.gateway.domain.usecase.CheckHealthStatusUseCase
 import dev.kigya.headway.gateway.domain.usecase.GetHomeScreenUseCase
 import dev.kigya.headway.gateway.domain.usecase.InviteUserUseCase
+import dev.kigya.headway.gateway.domain.usecase.LearningQuestionsGraphqlUseCases
 import dev.kigya.headway.gateway.domain.usecase.LoginAsGuestUseCase
 import dev.kigya.headway.gateway.domain.usecase.LoginWithGoogleUseCase
 import dev.kigya.headway.gateway.domain.usecase.RefreshAccessTokenUseCase
@@ -22,4 +23,5 @@ internal data class GatewayApiBindings(
     val resolvePrincipal: ResolvePrincipalUseCase,
     val getHomeScreen: GetHomeScreenUseCase,
     val preparation: PreparationGraphqlServices,
+    val learningQuestions: LearningQuestionsGraphqlUseCases,
 )

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/presentation/routes/GatewayRoutes.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/presentation/routes/GatewayRoutes.kt
@@ -70,4 +70,32 @@ internal sealed interface GatewayGraphqlOperation {
     data object PreparationSessionSummary : GatewayGraphqlOperation {
         override val name: String = "preparationSessionSummary"
     }
+
+    data object LearningQuestionsCatalog : GatewayGraphqlOperation {
+        override val name: String = "learningQuestionsCatalog"
+    }
+
+    data object LearningQuestionsPage : GatewayGraphqlOperation {
+        override val name: String = "learningQuestionsPage"
+    }
+
+    data object LearningQuestionsSearch : GatewayGraphqlOperation {
+        override val name: String = "learningQuestionsSearch"
+    }
+
+    data object LearningQuestion : GatewayGraphqlOperation {
+        override val name: String = "learningQuestion"
+    }
+
+    data object LearningQuestionRemarks : GatewayGraphqlOperation {
+        override val name: String = "learningQuestionRemarks"
+    }
+
+    data object AddLearningQuestionRemark : GatewayGraphqlOperation {
+        override val name: String = "addLearningQuestionRemark"
+    }
+
+    data object LogoutGuest : GatewayGraphqlOperation {
+        override val name: String = "logoutGuest"
+    }
 }

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/presentation/schema/LearningQuestionsSchema.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/presentation/schema/LearningQuestionsSchema.kt
@@ -1,0 +1,183 @@
+package dev.kigya.headway.gateway.presentation.schema
+
+import com.apurebase.kgraphql.Context
+import com.apurebase.kgraphql.schema.dsl.SchemaBuilder
+import dev.kigya.headway.gateway.core.exception.GatewayErrorReason
+import dev.kigya.headway.gateway.core.exception.GatewayException
+import dev.kigya.headway.gateway.domain.auth.GatewayAuthorizationPolicy
+import dev.kigya.headway.gateway.domain.auth.GatewayOperation
+import dev.kigya.headway.gateway.domain.usecase.LearningQuestionsGraphqlUseCases
+import dev.kigya.headway.gateway.domain.usecase.ResolvePrincipalUseCase
+import dev.kigya.headway.gateway.graphql.GraphqlRequestContext
+import dev.kigya.headway.gateway.model.GatewayLearningProgressState
+import dev.kigya.headway.gateway.model.GatewayLearningQuestion
+import dev.kigya.headway.gateway.model.GatewayLearningQuestionRemark
+import dev.kigya.headway.gateway.model.GatewayLearningQuestionsCatalog
+import dev.kigya.headway.gateway.model.GatewayLearningQuestionsPage
+import dev.kigya.headway.gateway.model.GatewayLearningQuestionsSearchResult
+import dev.kigya.headway.gateway.model.GatewayLearningSkillGroup
+import dev.kigya.headway.gateway.model.GatewayLearningTag
+import dev.kigya.headway.gateway.model.GatewayPrincipal
+import dev.kigya.headway.gateway.model.GatewayUser
+import dev.kigya.headway.gateway.presentation.routes.GatewayGraphqlOperation
+import java.util.UUID
+
+internal fun SchemaBuilder.learningQuestionsSchema(
+    resolvePrincipal: ResolvePrincipalUseCase,
+    learningQuestions: LearningQuestionsGraphqlUseCases,
+) {
+    registerLearningTypes()
+    registerLearningQueries(
+        resolvePrincipal = resolvePrincipal,
+        learningQuestions = learningQuestions,
+    )
+    registerLearningMutations(
+        resolvePrincipal = resolvePrincipal,
+        learningQuestions = learningQuestions,
+    )
+}
+
+private fun SchemaBuilder.registerLearningTypes() {
+    enum<GatewayLearningSkillGroup>()
+    enum<GatewayLearningProgressState>()
+    type<GatewayLearningTag>()
+    type<GatewayLearningQuestion>()
+    type<GatewayLearningQuestionsCatalog>()
+    type<GatewayLearningQuestionsPage>()
+    type<GatewayLearningQuestionsSearchResult>()
+    type<GatewayLearningQuestionRemark>()
+}
+
+private fun SchemaBuilder.registerLearningQueries(
+    resolvePrincipal: ResolvePrincipalUseCase,
+    learningQuestions: LearningQuestionsGraphqlUseCases,
+) {
+    query(GatewayGraphqlOperation.LearningQuestionsCatalog.name) {
+        resolver { subjectUserId: UUID?, ctx: Context ->
+            val requestContext = ctx.graphqlRequestContext()
+            val principal = resolvePrincipal(requestContext.authorizationHeader)
+            GatewayAuthorizationPolicy.ensure(principal, GatewayOperation.LearningRead)
+            learningQuestions.learningQuestionsCatalog(
+                principal = principal,
+                locale = requestContext.appLocale,
+                subjectUserId = subjectUserId,
+            )
+        }
+    }
+
+    query(GatewayGraphqlOperation.LearningQuestionsPage.name) {
+        resolver {
+                skillGroup: GatewayLearningSkillGroup,
+                limit: Int,
+                afterQuestionId: Long?,
+                subjectUserId: UUID?,
+                ctx: Context,
+            ->
+            val requestContext = ctx.graphqlRequestContext()
+            val principal = resolvePrincipal(requestContext.authorizationHeader)
+            GatewayAuthorizationPolicy.ensure(principal, GatewayOperation.LearningRead)
+            learningQuestions.learningQuestionsPage(
+                principal = principal,
+                locale = requestContext.appLocale,
+                skillGroup = skillGroup,
+                limit = limit,
+                afterQuestionId = afterQuestionId,
+                subjectUserId = subjectUserId,
+            )
+        }
+    }
+
+    query(GatewayGraphqlOperation.LearningQuestionsSearch.name) {
+        resolver { searchQuery: String, subjectUserId: UUID?, ctx: Context ->
+            val requestContext = ctx.graphqlRequestContext()
+            val principal = resolvePrincipal(requestContext.authorizationHeader)
+            GatewayAuthorizationPolicy.ensure(principal, GatewayOperation.LearningRead)
+            learningQuestions.learningQuestionsSearch(
+                principal = principal,
+                locale = requestContext.appLocale,
+                query = searchQuery,
+                subjectUserId = subjectUserId,
+            )
+        }
+    }
+
+    query(GatewayGraphqlOperation.LearningQuestion.name) {
+        resolver { questionId: Long, subjectUserId: UUID?, ctx: Context ->
+            val requestContext = ctx.graphqlRequestContext()
+            val principal = resolvePrincipal(requestContext.authorizationHeader)
+            GatewayAuthorizationPolicy.ensure(principal, GatewayOperation.LearningRead)
+            learningQuestions.learningQuestion(
+                principal = principal,
+                locale = requestContext.appLocale,
+                questionId = questionId,
+                subjectUserId = subjectUserId,
+            )
+        }
+    }
+
+    query(GatewayGraphqlOperation.LearningQuestionRemarks.name) {
+        resolver { questionId: Long, subjectUserId: UUID, ctx: Context ->
+            val requestContext = ctx.graphqlRequestContext()
+            val user = ensureLearningUser(resolvePrincipal, requestContext)
+            learningQuestions.learningQuestionRemarks(
+                user = user,
+                questionId = questionId,
+                subjectUserId = subjectUserId,
+            )
+        }
+    }
+}
+
+private fun SchemaBuilder.registerLearningMutations(
+    resolvePrincipal: ResolvePrincipalUseCase,
+    learningQuestions: LearningQuestionsGraphqlUseCases,
+) {
+    mutation(GatewayGraphqlOperation.AddLearningQuestionRemark.name) {
+        resolver { questionId: Long, subjectUserId: UUID, body: String, ctx: Context ->
+            val requestContext = ctx.graphqlRequestContext()
+            val user = ensureLearningUser(resolvePrincipal, requestContext)
+            val principal = GatewayPrincipal.User(user)
+            GatewayAuthorizationPolicy.ensure(principal, GatewayOperation.LearningRemarkWrite)
+            learningQuestions.addLearningQuestionRemark(
+                user = user,
+                questionId = questionId,
+                subjectUserId = subjectUserId,
+                body = body,
+            )
+        }
+    }
+
+    mutation(GatewayGraphqlOperation.LogoutGuest.name) {
+        resolver { ctx: Context ->
+            val requestContext = ctx.graphqlRequestContext()
+            val principal = resolvePrincipal(requestContext.authorizationHeader)
+            GatewayAuthorizationPolicy.ensure(principal, GatewayOperation.LogoutGuest)
+            when (principal) {
+                is GatewayPrincipal.Guest ->
+                    learningQuestions.logoutGuest(sessionId = principal.guestSessionId)
+
+                is GatewayPrincipal.User ->
+                    throw GatewayException.Internal("Unexpected user principal for logoutGuest")
+            }
+            true
+        }
+    }
+}
+
+private fun Context.graphqlRequestContext(): GraphqlRequestContext =
+    get<GraphqlRequestContext>() ?: throw GatewayException.Internal("Missing GraphQL request context")
+
+private suspend fun ensureLearningUser(
+    resolvePrincipal: ResolvePrincipalUseCase,
+    requestContext: GraphqlRequestContext,
+): GatewayUser {
+    val principal = resolvePrincipal(requestContext.authorizationHeader)
+    return when (principal) {
+        is GatewayPrincipal.User -> principal.user
+        is GatewayPrincipal.Guest ->
+            throw GatewayException.Forbidden(
+                reason = GatewayErrorReason.GUEST_NOT_ALLOWED,
+                message = "Guests cannot access learning remarks",
+            )
+    }
+}

--- a/server/gateway/src/test/kotlin/dev/kigya/headway/gateway/presentation/GatewaySecurityRoutesTest.kt
+++ b/server/gateway/src/test/kotlin/dev/kigya/headway/gateway/presentation/GatewaySecurityRoutesTest.kt
@@ -3,9 +3,17 @@ package dev.kigya.headway.gateway.presentation
 import dev.kigya.headway.auth.api.model.out.AuthPrincipalType
 import dev.kigya.headway.auth.api.model.out.AuthValidateTokenResponse
 import dev.kigya.headway.common.util.Environment
+import dev.kigya.headway.database.api.model.`in`.DatabaseLearningFacilitatedPageQuery
+import dev.kigya.headway.database.api.model.`in`.DatabaseLearningRemarkCreateRequestDto
 import dev.kigya.headway.database.api.model.`in`.DatabasePreparationSelectQuestionRequestDto
 import dev.kigya.headway.database.api.model.`in`.DatabasePreparationStartSessionRequestDto
 import dev.kigya.headway.database.api.model.`in`.DatabasePreparationSubmitOutcomeRequestDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningCatalogResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningPageResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningQuestionDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningRemarkDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningSearchResponseDto
+import dev.kigya.headway.database.api.model.out.DatabaseLearningSkillGroup
 import dev.kigya.headway.database.api.model.out.DatabasePreparationCatalogResponseDto
 import dev.kigya.headway.database.api.model.out.DatabasePreparationEmployeesResponseDto
 import dev.kigya.headway.database.api.model.out.DatabasePreparationReadinessResponseDto
@@ -18,6 +26,7 @@ import dev.kigya.headway.gateway.core.exception.GatewayException
 import dev.kigya.headway.gateway.domain.repository.AuthRepositoryContract
 import dev.kigya.headway.gateway.domain.repository.DatabaseRepositoryContract
 import dev.kigya.headway.gateway.domain.repository.HomeRepositoryContract
+import dev.kigya.headway.gateway.domain.repository.LearningQuestionsRepositoryContract
 import dev.kigya.headway.gateway.domain.repository.PreparationRepositoryContract
 import dev.kigya.headway.gateway.domain.usecase.CheckHealthStatusUseCase
 import dev.kigya.headway.gateway.domain.usecase.FinishPreparationSessionUseCase
@@ -28,6 +37,7 @@ import dev.kigya.headway.gateway.domain.usecase.GetPreparationSessionStateUseCas
 import dev.kigya.headway.gateway.domain.usecase.GetPreparationSessionSummaryUseCase
 import dev.kigya.headway.gateway.domain.usecase.GetPreparationSetupEmployeesUseCase
 import dev.kigya.headway.gateway.domain.usecase.InviteUserUseCase
+import dev.kigya.headway.gateway.domain.usecase.LearningQuestionsGraphqlUseCases
 import dev.kigya.headway.gateway.domain.usecase.LoginAsGuestUseCase
 import dev.kigya.headway.gateway.domain.usecase.LoginWithGoogleUseCase
 import dev.kigya.headway.gateway.domain.usecase.RefreshAccessTokenUseCase
@@ -98,6 +108,9 @@ class GatewaySecurityRoutesTest {
                 preparationRepository = StubPreparationRepositoryContract,
             ),
         )
+
+    private val stubLearningQuestionsGraphqlUseCases: LearningQuestionsGraphqlUseCases =
+        LearningQuestionsGraphqlUseCases(repository = StubLearningQuestionsRepositoryContract)
 
     @Test
     fun `graphql inviteUser returns unauthorized without authorization header`() = testApplication {
@@ -403,6 +416,7 @@ class GatewaySecurityRoutesTest {
                         },
                     ),
                     preparation = stubPreparationGraphqlServices,
+                    learningQuestions = stubLearningQuestionsGraphqlUseCases,
                 ),
             )
         }
@@ -451,6 +465,7 @@ class GatewaySecurityRoutesTest {
                         homeRepository = EmployeeHomeReadinessTestHomeRepository,
                     ),
                     preparation = stubPreparationGraphqlServices,
+                    learningQuestions = stubLearningQuestionsGraphqlUseCases,
                 ),
             )
         }
@@ -490,8 +505,77 @@ class GatewaySecurityRoutesTest {
                     homeRepository = LocaleAwareDeveloperTestHomeRepository,
                 ),
                 preparation = stubPreparationGraphqlServices,
+                learningQuestions = stubLearningQuestionsGraphqlUseCases,
             ),
         )
+    }
+}
+
+private object StubLearningQuestionsRepositoryContract : LearningQuestionsRepositoryContract {
+
+    override suspend fun getPublicCatalog(locale: String): DatabaseLearningCatalogResponseDto =
+        throw AssertionError("stub")
+
+    override suspend fun getCatalog(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        locale: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningCatalogResponseDto = throw AssertionError("stub")
+
+    override suspend fun getPublicPage(
+        locale: String,
+        skillGroup: DatabaseLearningSkillGroup,
+        limit: Int,
+        afterQuestionId: Long?,
+    ): DatabaseLearningPageResponseDto = throw AssertionError("stub")
+
+    override suspend fun getPage(
+        query: DatabaseLearningFacilitatedPageQuery,
+    ): DatabaseLearningPageResponseDto = throw AssertionError("stub")
+
+    override suspend fun getPublicSearch(
+        locale: String,
+        query: String,
+    ): DatabaseLearningSearchResponseDto = throw AssertionError("stub")
+
+    override suspend fun getSearch(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        locale: String,
+        query: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningSearchResponseDto = throw AssertionError("stub")
+
+    override suspend fun getPublicQuestion(
+        questionId: Long,
+        locale: String,
+    ): DatabaseLearningQuestionDto = throw AssertionError("stub")
+
+    override suspend fun getQuestion(
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        questionId: Long,
+        locale: String,
+        subjectUserId: UUID?,
+    ): DatabaseLearningQuestionDto = throw AssertionError("stub")
+
+    override suspend fun listRemarks(
+        questionId: Long,
+        subjectUserId: UUID,
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+    ): List<DatabaseLearningRemarkDto> = throw AssertionError("stub")
+
+    override suspend fun addRemark(
+        questionId: Long,
+        facilitatorUserId: UUID,
+        facilitatorRole: DatabaseUserRole,
+        body: DatabaseLearningRemarkCreateRequestDto,
+    ): DatabaseLearningRemarkDto = throw AssertionError("stub")
+
+    override suspend fun revokeGuestSession(sessionId: UUID) {
+        throw AssertionError("stub")
     }
 }
 

--- a/server/home/api/src/main/kotlin/dev/kigya/headway/home/api/model/resource/HomeResource.kt
+++ b/server/home/api/src/main/kotlin/dev/kigya/headway/home/api/model/resource/HomeResource.kt
@@ -1,6 +1,7 @@
 package dev.kigya.headway.home.api.model.resource
 
 import io.ktor.resources.Resource
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -10,6 +11,7 @@ class HomeResource {
     @Serializable
     @Resource("screen")
     data class Screen(
+        @SerialName("parent")
         val parent: HomeResource = HomeResource(),
     )
 }


### PR DESCRIPTION
## Summary

Delivers spec **003** learning-questions server work: internal database HTTP API, gateway GraphQL, guest JWT/session coordination, and contract hygiene (`@SerialName`, `data/` layout vs `repository/`).

## Changes

- **Database service:** learning catalog/page/search/by-id, facilitated flows, remarks, progress; guest session register/revoke/validate; preparation outcome sync into learning progress; routing + DI.
- **Gateway:** `LearningQuestionsRepository` via `upstreamCall`, GraphQL schema/use cases, auth operations for guest and learning.
- **Auth:** guest session registration/validation against database; JWT payload adjustments as needed.
- **API models:** `DatabaseResource` extensions, DTOs, `@SerialName` on serializable fields; admin/home resource tweaks.
- **Structure:** `LearningQuestionPreparationSync` → `data/learning/`, facilitator scope helpers → `data/scope/`.
- **Cursor:** Memory Bank + lessons §18–§19, `specify-rules` touch.

Project board: https://github.com/users/kigya/projects/4/views/2

Closes #3

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/kigya/Headway/82)
<!-- GitContextEnd -->