### PR TITLE
FULLSTACK-HEADWAY-86: KMP Google auth, session stack, gateway hardening, Render baseline

### DIFF
--- a/.cursor/memory-bank/systemPatterns.md
+++ b/.cursor/memory-bank/systemPatterns.md
@@ -9,9 +9,13 @@ Patterns called out in `AGENTS.md` / `client/AGENTS.md` / `server/AGENTS.md` and
 - **Client errors:** model expected failures with **`Outcome`**, not ad-hoc exceptions for domain cases.
 - **Client navigation:** use **`NavigatorContract`** / `NavigationIntent`, not ad-hoc platform navigation.
 - **Server gateways:** wrap outbound HTTP in **`upstreamCall`** with consistent dependency error mapping.
-- **Server serialization:** every `@Serializable` property uses `@SerialName` with the real wire key; when annotating existing types, match the current JSON/query names (see `.cursor/rules/lessons-learned.mdc` §18).
+- **kotlinx.serialization (server + client):** every `@Serializable` property uses `@SerialName` with the real persisted/wire key; polymorphic sealed variants annotate both discriminator and nested properties (see lessons-learned §18).
 - **Server `data` layout:** `data/repository` holds only repository implementations; scope queries, sync helpers, and similar live under sibling `data/<role>/` packages (see lessons-learned §19).
 - **Gateway health:** `CheckHealthStatusUseCase` probes each downstream service’s **`/healthz`** (under that service’s base URL) via `BaseHttpProbe`; add a probe for every Koin-tagged `HttpClient` the gateway uses for microservices (auth, database, home, …).
+- **Platform adapters (Android, etc.):** inject `CoroutineDispatcher` / DI-owned `CoroutineScope` for IO and long-lived stores; cancel custom scopes on Koin `onClose`; avoid unused constructor fields; primary constructors list **`val`/`var` before plain parameters**; secure session storage implements **`Outcome`-returning** `SecureSessionStorageContract`, mapped to domain errors in `LocalSessionPersistenceRepository` (see lessons-learned §10 companion vs top-level const, §21, §29, §30).
+- **Naming:** prefer full-word locals over `err` / `msg` / `idx` / `ex`-style abbreviations unless the short form is a standard wire/API token (see lessons-learned §31).
+- **Client Gradle:** no empty `*MainDependencies { }` blocks in module `build.gradle.kts`; drop unused `extension.*MainDependencies` imports (see lessons-learned §32). Shared `implementation(project(…))` / `implementation(core.…)` used on **all** targets belongs in **`commonMainDependencies`**, not duplicated per platform (§33).
+- **Thin typed values:** single-field wrappers (e.g. config URLs in DI) use **`@JvmInline value class`**, not `data class`, unless `copy`/data-class semantics are required (§34).
 - **Lessons:** cumulative anti-patterns live in `.cursor/rules/lessons-learned.mdc` (curated, not a dump of every chat).
 
 ## Open questions

--- a/.cursor/rules/lessons-learned.mdc
+++ b/.cursor/rules/lessons-learned.mdc
@@ -97,10 +97,10 @@ alwaysApply: true
 
 ### 10
 
-- **Rule:** Place file-level `private const val` at the **bottom** of the file, after the declarations that reference them.
-- **Why it exists:** Project convention keeps literals and tags grouped at the end so the main API and behavior read top-down first.
-- **Bad pattern (short):** A block of `private const val` immediately after imports or above the primary `@Composable` / `actual` entry points.
-- **Correct pattern (short):** Package, imports, types and functions, then a trailing `private const val` section (e.g. `SystemBarsColor.ios.kt`).
+- **Rule:** Place file-level `private const val` at the **bottom** of the file, after the declarations that reference them; use **top-level** `private const val`, not a `private companion object` block, when literals are file-private.
+- **Why it exists:** Project convention keeps literals and tags grouped at the end so the main API and behavior read top-down first; a companion object is unnecessary noise for file-scoped constants.
+- **Bad pattern (short):** A block of `private const val` immediately after imports or above the primary `@Composable` / `actual` entry points; literals above Koin `actual fun sessionPlatformModule() { module { … } }` or above the main repository `class`; `private const val` sandwiched between preview/test helper types; `private companion object { const val … }` for values only this file needs.
+- **Correct pattern (short):** Package, imports, types and functions (including `actual`/Koin modules), then one trailing top-level `private const val` section (e.g. `SystemBarsColor.ios.kt`, `SessionPlatformModule.*.kt`).
 
 ---
 
@@ -169,10 +169,10 @@ alwaysApply: true
 
 ### 18
 
-- **Rule:** On the server, every serializable **property** on `@Serializable` types (DTOs, gateway GraphQL models, nested Ktor `@Resource` parameter classes, enums) must be annotated with `@SerialName("…")` using the **actual wire key** (query/path/JSON) for that type.
-- **Why it exists:** Explicit keys document the contract and prevent silent renames when Kotlin property names change; mixed annotated/unannotated fields are easy to miss in review and drift from inter-service expectations.
-- **Bad pattern (short):** `@Serializable data class X( @SerialName("a") val a: String, val b: String )` or omitting `@SerialName` on Ktor resource `parent` / path parameters while other fields use snake_case query keys.
-- **Correct pattern (short):** Annotate **each** constructor property (including `parent` on resources and UUID/custom-serialized fields); when formalizing legacy DTOs, set `@SerialName` to match the **previous** implicit kotlinx name (often camelCase) or the established snake_case API—never rename keys in the same edit unless intentionally versioning the contract.
+- **Rule:** Every serializable **property** on `@Serializable` types must use `@SerialName("…")` with the **real persisted or wire key** (JSON field name, query/path key, polymorphic type tag): **server** DTOs, gateway GraphQL models, Ktor `@Resource` parameters, enums, **and client `kotlinx.serialization` models** (e.g. `LocalSessionRecord` in secure storage). **Polymorphic** sealed subclasses need `@SerialName` on each variant for the type discriminator **and** on every property inside them.
+- **Why it exists:** Explicit keys document the contract and prevent silent renames when Kotlin property names change; mixed annotated/unannotated fields are easy to miss in review and drift from APIs, stored payloads, or inter-service expectations.
+- **Bad pattern (short):** `@Serializable data class X( @SerialName("a") val a: String, val b: String )`; client `data class Guest(val accessToken: String, …)` without `@SerialName` on each property; omitting `@SerialName` on Ktor resource `parent` while other fields use snake_case query keys.
+- **Correct pattern (short):** Annotate **each** constructor property (including `parent` on resources and UUID/custom-serialized fields); for existing payloads, set `@SerialName` to match the **previous** implicit kotlinx name (often camelCase) or the established API—never rename keys in the same edit unless intentionally versioning the contract.
 
 ---
 
@@ -191,3 +191,129 @@ alwaysApply: true
 - **Why it exists:** Those APIs already start collecting when the composable is active; an extra read in `SideEffect` does not change subscription behavior, hides real intent, and invites dead code.
 - **Bad pattern (short):** `val state by viewModel.uiState.collectAsStateWithLifecycle()` plus `SideEffect { state.shouldDisplayText }` (or any field) when nothing in the tree uses `state` for UI or side effects.
 - **Correct pattern (short):** If the screen has no UI tied to store state yet, skip collection until it does; otherwise read the fields where they matter (parameters to child composables, `when`, etc.) and rely on `collectAsStateWithLifecycle()` alone for lifecycle-aware collection.
+
+---
+
+### 21
+
+- **Rule:** In Android and other platform adapters, **inject** `CoroutineDispatcher` (or a DI-owned `CoroutineScope` used for long-lived work like DataStore); **cancel** that scope when the Koin definition clears; remove **unused** constructor-held fields after refactors.
+- **Why it exists:** Hard-coded `Dispatchers.IO` and ad-hoc `CoroutineScope(SupervisorJob() + …)` are hard to test, easy to leak across holder recreation, and hide lifecycle ownership; dead fields (e.g. unused `applicationContext`) violate hygiene and confuse readers.
+- **Bad pattern (short):** `CoroutineScope(SupervisorJob() + Dispatchers.IO)` inside the type with no `cancel`; `withContext(Dispatchers.IO)` / `scope = … + Dispatchers.IO` without injection; `outcomeSuspendCatchingOn(dispatcher = Dispatchers.IO/Dispatchers.Default, …)` in wasm/iOS/desktop storage adapters; keeping `applicationContext` or other members that nothing reads.
+- **Correct pattern (short):** Inject `CoroutineDispatcher` (e.g. Koin `get(named(DispatcherKey.IO))`; wasm `dispatcherModule` may map IO to `Dispatchers.Default`); optionally a `CoroutineScope` from Koin; use `single(createdAtStart = false) { … } onClose { it.cancel() }` (or equivalent) for custom scopes; delete unused properties and imports.
+
+---
+
+### 22
+
+- **Rule:** In Ktor `StatusPages`, return error **text bodies** with `respondText` (plain text) when other services consume errors via `HttpResponse.bodyAsText()`; register domain-specific handlers **before** `handleDefaultExceptions()` so `Throwable` does not swallow typed exceptions.
+- **Why it exists:** `call.respond(HttpStatusCode, message = …)` does not reliably set a readable plain body for Ktor clients; the gateway then sees an empty body and maps upstream 400 to a generic `"Bad request"` GraphQL message, hiding the real cause (e.g. validation or deserialization).
+- **Bad pattern (short):** `call.respond(status = HttpStatusCode.BadRequest, message = exception.message.orEmpty())` in shared StatusPages; installing `handleDefaultExceptions()` before service-specific `exception<DomainException>` so the catch-all `Throwable` handler wins.
+- **Correct pattern (short):** `call.respondText(text = exception.describeForHttpStatusText("Bad request"), contentType = ContentType.Text.Plain, status = HttpStatusCode.BadRequest)` (or equivalent non-blank text); `install(StatusPages) { handleDomainExceptions(); handleDefaultExceptions() }`.
+
+---
+
+### 23
+
+- **Rule:** Set **`GOOGLE_TOKEN_AUDIENCE`** (auth service) to the **same OAuth 2.0 Web client ID** the mobile app passes to **`requestIdToken(webClientId)`** (Android `google_web_client_id` / iOS equivalent), not the Android-only or iOS-only client ID.
+- **Why it exists:** `GoogleIdTokenVerifier.setAudience` must match the ID token’s `aud` claim; a mismatch makes `verify()` return null and surfaces as **“Invalid Google token”** / `INVALID_ACCESS_TOKEN` even with a real user sign-in.
+- **Bad pattern (short):** Placeholder or stale `GOOGLE_TOKEN_AUDIENCE` in `docker/*/env.auth` that does not match the Web client ID wired in the client app.
+- **Correct pattern (short):** Keep `GOOGLE_TOKEN_AUDIENCE` aligned with the Web client ID used for ID tokens; per-environment deploy config should still use that environment’s Web client if it differs from dev.
+
+---
+
+### 24
+
+- **Rule:** Headway **desktop** loopback OAuth uses the **same Web OAuth 2.0 client ID** as mobile `id_token` audience: register **Authorized redirect URI** `http://127.0.0.1:<port>/oauth2callback` on that **Web** client. **Desktop**-type clients in Google Cloud often have **no redirect URI fields**; they are not required for this flow. Auth **`GOOGLE_TOKEN_AUDIENCE`** may be a **comma-separated** list if multiple client IDs can appear in `aud`; a single Web client ID is enough when desktop and mobile share it.
+- **Why it exists:** The desktop app must exchange the authorization code for an `id_token` whose `aud` matches what `GoogleIdTokenVerifier` accepts; loopback redirect must be allowlisted on the client used in the authorize + token steps.
+- **Bad pattern (short):** Expecting a separate Desktop OAuth client redirect UI in Console when the app is configured to use the Web client; or omitting the loopback redirect URI on the Web client used for desktop PKCE.
+- **Correct pattern (short):** Web client ID in app + `http://127.0.0.1:8405/oauth2callback` under **Authorized redirect URIs** for that Web client; keep `GOOGLE_TOKEN_AUDIENCE` aligned with that client ID (comma-separated only if you intentionally issue tokens for more than one OAuth client).
+
+---
+
+### 25
+
+- **Rule:** **iOS** Google Sign-In requires **`CFBundleURLTypes`** in the app **`Info.plist`** with URL scheme **`com.googleusercontent.apps.<ios_client_id_prefix>`** (reversed client id: everything before `.apps.googleusercontent.com` in the **iOS** OAuth client id). Without it, `GIDSignIn` throws at runtime: *missing support for the following URL schemes*.
+- **Why it exists:** Google redirects back to the app via that custom URL scheme; the SDK validates it before starting the flow.
+- **Bad pattern (short):** `GIDConfiguration` + `signIn(withPresenting:)` in Swift without the matching `Info.plist` URL scheme.
+- **Correct pattern (short):** Add the scheme to `Info.plist` (and keep `onOpenURL` / `handle(url)` wired as in the integration guide).
+
+---
+
+### 26
+
+- **Rule:** **Desktop** token exchange against a **Web** OAuth client may require **`client_secret`** on `https://oauth2.googleapis.com/token` even with PKCE; support it only via **local env** (e.g. `HEADWAY_GOOGLE_OAUTH_CLIENT_SECRET`), never commit the secret.
+- **Why it exists:** Google treats Web clients as confidential; without the secret the response often has no `id_token`, so the loopback page shows sign-in failed.
+- **Bad pattern (short):** Hard-coding the client secret in source or expecting PKCE alone to succeed for every Web client configuration.
+- **Correct pattern (short):** Copy the Web client secret from Google Cloud Console into a local / machine env var for desktop dev; production desktop builds need a distribution-safe approach (or a different OAuth client model).
+
+---
+
+### 27
+
+- **Rule:** For **Web / GSI** (`google.accounts.id`), add the app’s exact **Authorized JavaScript origin** in Google Cloud for the **same Web OAuth 2.0 client** (scheme + host + **port**). Local webpack dev is a distinct origin (must match `devServer.port` in `app/headwayWeb/build.gradle.kts`, e.g. `http://localhost:8765` vs `http://localhost:8080`).
+- **Why it exists:** Google returns **Error 400: origin_mismatch** and the One Tap / ID flow never yields a credential; the app then shows the generic error fallback even though the backend is fine.
+- **Bad pattern (short):** Only `http://localhost` without port, or a production origin only, while developing on `wasmJsBrowserDevelopmentRun` at another port.
+- **Correct pattern (short):** In **Credentials → Web client → Authorized JavaScript origins**, add each dev URL you use (must match the pinned **devServer.port** in `app/headwayWeb/build.gradle.kts`, currently `http://localhost:8765`).
+
+---
+
+### 28
+
+- **Rule:** The **gateway** must install **Ktor CORS** for **browser** GraphQL clients when `ENV` is not `prod` (`anyHost()` + `POST`/`OPTIONS` + `Authorization` + `Content-Type` + `allowNonSimpleContentTypes`); align allowed headers with gateway usage (e.g. `X-Headway-Locale`).
+- **Why it exists:** After a valid Google **ID token**, Apollo’s `POST` from `http://localhost:<webpackPort>` to `http://127.0.0.1:8080/...` is **cross-origin**; without CORS the browser blocks the response and the client maps the failure to **`Network` / `NetworkUnavailable`** (see `HeadwayGraphqlExecutor` + `SessionGraphqlFailureMapper`), not a GraphQL error body.
+- **Bad pattern (short):** Fixing only **Authorized JavaScript origins** while the gateway sends **no** `Access-Control-Allow-*` headers for `/api/v1/graphql`.
+- **Correct pattern (short):** `installHeadwayGatewayCors` in gateway presentation (dev/non-prod); for **prod** browser traffic, replace `anyHost()` with an explicit allowlist (env-driven) before shipping public web.
+
+---
+
+### 29
+
+- **Rule:** In a primary constructor, list **`val` / `var` properties first**, then **plain constructor parameters** (no property), in a stable order across the project.
+- **Why it exists:** Keeps “stored state” visually grouped at the top; avoids mixing `context: Context`-style parameters ahead of `private val` dependencies and makes reviews consistent.
+- **Bad pattern (short):** `class X(context: Context, private val io: CoroutineDispatcher, scope: CoroutineScope)`.
+- **Correct pattern (short):** `class X(private val io: CoroutineDispatcher, context: Context, scope: CoroutineScope)`.
+
+---
+
+### 30
+
+- **Rule:** `SecureSessionStorageContract` and similar **platform I/O adapters** must return **`Outcome<SecureSessionStorageError, …>`** (or an equivalent module-local sealed error), using **`outcomeSuspendCatching` / `outcomeSuspendCatchingOn`** so storage failures are typed, not silent throws; **domain repositories** map that failure to **`SessionDomainError`** (or the feature’s domain error) at the boundary.
+- **Why it exists:** Raw suspend APIs hide DataStore / filesystem / Keychain / `localStorage` failures; `Outcome` matches client policy and lets `LocalSessionPersistenceRepository` report `LocalPersistenceFailed` consistently.
+- **Bad pattern (short):** `suspend fun loadPayload(): String?` with uncaught `IOException` / DataStore errors propagating as generic exceptions.
+- **Correct pattern (short):** `suspend fun loadPayload(): Outcome<SecureSessionStorageError, String?>` with `outcomeSuspendCatchingOn(ioDispatcher) { … }`; caller uses `when (loaded) { Success -> …; Failure -> Outcome.failure(SessionDomainError.LocalPersistenceFailed) }`.
+
+---
+
+### 31
+
+- **Rule:** Prefer **full-word local names** over cryptic abbreviations (`error` not `err`, `message` not `msg`, `index` not `idx`, `context` not `ctx`, `gatewayException` not `ex` in tests) when the name is not a widely understood domain acronym on the wire.
+- **Why it exists:** Abbreviations save a few characters but slow scanning and review; aligned with root [AGENTS.md](../../AGENTS.md) verb-led / readable naming spirit.
+- **Bad pattern (short):** `val err = …`, `val msg = …`, `val ex = assertFailsWith<…>`.
+- **Correct pattern (short):** `val tokenError = …`, `val badRequestMessage = …`, `val gatewayException = response.toGatewayException(…)`.
+
+---
+
+### 32
+
+- **Rule:** In client **`build.gradle.kts`**, do not declare **empty** `commonMainDependencies` / `androidMainDependencies` / `iosMainDependencies` / `desktopMainDependencies` / `wasmMainDependencies` blocks; remove the block and the unused `import extension.*MainDependencies`.
+- **Why it exists:** Empty blocks look like forgotten configuration, add noise, and keep stale imports; when a platform needs dependencies, add the block then.
+- **Bad pattern (short):** `iosMainDependencies {\n}\n\ndesktopMainDependencies {\n}` with no `projects` / `libs` body.
+- **Correct pattern (short):** Only blocks that contain at least one `projects { … }` or `libs { … }` (or other real configuration inside the helper).
+
+---
+
+### 33
+
+- **Rule:** If a **`projects { implementation(…) }`** dependency is **the same on every KMP target** (`androidMain` / `iosMain` / `desktopMain` / `wasmMain`), declare it once in **`commonMainDependencies`** instead of repeating per platform.
+- **Why it exists:** Duplication drifts (one target updated, others not), clutters build scripts, and contradicts KMP’s shared `commonMain` model; platform blocks should hold only truly platform-specific deps (e.g. `koin.android`, `kotlinx.browser.wasm.js`).
+- **Bad pattern (short):** Same `implementation(core.secureStorage)` under `androidMainDependencies`, `iosMainDependencies`, `desktopMainDependencies`, and `wasmMainDependencies`.
+- **Correct pattern (short):** `implementation(core.secureStorage)` inside `commonMainDependencies { projects { … } }`; platform blocks only for extras.
+
+---
+
+### 34
+
+- **Rule:** For **thin wrappers** with a **single** read-only property (URLs, ids, typed strings in DI), prefer **`@JvmInline value class`** over **`data class`** when you do not need `copy`, `componentN`, or distinct heap identity.
+- **Why it exists:** Fewer allocations and clearer intent than a full data class; matches Kotlin guidance for domain “newtypes”; aligns with lessons-learned §9 for bounded unions built from value classes.
+- **Bad pattern (short):** `data class HeadwayGraphqlHttpUrl(val value: String)` for a pass-through holder only used as `get<HeadwayGraphqlHttpUrl>().value`.
+- **Correct pattern (short):** `@JvmInline value class HeadwayGraphqlHttpUrl(val value: String)`.

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ captures
 **/.vscode
 
 .cursor/projects/
+.cursor/debug-*
 .playwright-mcp/
 specs/**

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ captures
 **/xcshareddata/WorkspaceSettings.xcsettings
 /server/docker/*
 !/server/docker/Dockerfile
+!/server/docker/render
+!/server/docker/render/**
 !/server/docker/template
 **/bin/
 **/lib/

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,50 +1,290 @@
-# [PROJECT_NAME] Constitution
-<!-- Example: Spec Constitution, TaskFlow Constitution, etc. -->
+# Headway Engineering Constitution
+
+This document is the constitutional source of truth for spec-driven work in the Headway monorepo. It translates the repository's `AGENTS.md`, path-specific `AGENTS.md` files, Cursor rules, and established system patterns into a single normative contract for planning, implementation, review, and verification.
+
+The key words MUST, MUST NOT, REQUIRED, SHOULD, SHOULD NOT, and MAY are to be interpreted as described in RFC 2119.
 
 ## Core Principles
 
-### [PRINCIPLE_1_NAME]
-<!-- Example: I. Library-First -->
-[PRINCIPLE_1_DESCRIPTION]
-<!-- Example: Every feature starts as a standalone library; Libraries must be self-contained, independently testable, documented; Clear purpose required - no organizational-only libraries -->
+### I. Closest Source Of Truth
+All work MUST start by identifying the paths it changes and loading the closest governing rules for those paths.
 
-### [PRINCIPLE_2_NAME]
-<!-- Example: II. CLI Interface -->
-[PRINCIPLE_2_DESCRIPTION]
-<!-- Example: Every library exposes functionality via CLI; Text in/out protocol: stdin/args → stdout, errors → stderr; Support JSON + human-readable formats -->
+- Repository-wide Kotlin policy comes from the root `AGENTS.md`.
+- `client/**` work MUST follow `client/AGENTS.md` in addition to the root rules.
+- `server/**` work MUST follow `server/AGENTS.md` in addition to the root rules.
+- `client/core/design-system/**` work MUST follow the design-system `AGENTS.md` in addition to the root and client rules.
+- `.cursor/rules/global.mdc` and `.cursor/rules/lessons-learned.mdc` MUST be treated as always-applicable guidance.
+- Client Kotlin work SHOULD also account for `.cursor/rules/client.mdc` and `.cursor/rules/detekt-guardrails.mdc`.
+- Server Kotlin work SHOULD also account for `.cursor/rules/server.mdc` and `.cursor/rules/detekt-guardrails.mdc`.
 
-### [PRINCIPLE_3_NAME]
-<!-- Example: III. Test-First (NON-NEGOTIABLE) -->
-[PRINCIPLE_3_DESCRIPTION]
-<!-- Example: TDD mandatory: Tests written → User approved → Tests fail → Then implement; Red-Green-Refactor cycle strictly enforced -->
+Implications:
 
-### [PRINCIPLE_4_NAME]
-<!-- Example: IV. Integration Testing -->
-[PRINCIPLE_4_DESCRIPTION]
-<!-- Example: Focus areas requiring integration tests: New library contract tests, Contract changes, Inter-service communication, Shared schemas -->
+- Plans, specs, and tasks MUST name the concrete paths or modules they affect.
+- Architectural decisions MUST be justified against the rules for those paths, not against generic Kotlin or framework advice.
+- If guidance overlaps, the most specific path-scoped rule wins.
+- Memory Bank context informs priorities and patterns, but MUST NOT override `AGENTS.md` or the rules.
 
-### [PRINCIPLE_5_NAME]
-<!-- Example: V. Observability, VI. Versioning & Breaking Changes, VII. Simplicity -->
-[PRINCIPLE_5_DESCRIPTION]
-<!-- Example: Text I/O ensures debuggability; Structured logging required; Or: MAJOR.MINOR.BUILD format; Or: Start simple, YAGNI principles -->
+### II. Explicit Architecture And Boundaries
+Headway favors explicit module boundaries, small public surfaces, and clear placement of behavior.
 
-## [SECTION_2_NAME]
-<!-- Example: Additional Constraints, Security Requirements, Performance Standards, etc. -->
+- Visibility MUST default to `internal`; visibility MAY be widened only when another module genuinely requires it.
+- Features and services MUST preserve the architecture already established in the repository instead of inventing parallel patterns.
+- UI, business logic, network orchestration, database access, and public contracts MUST remain in their designated layers.
+- Cross-module contracts MUST be reused rather than duplicated.
+- New abstractions MUST solve a real boundary problem and MUST NOT be introduced only for organizational aesthetics.
 
-[SECTION_2_CONTENT]
-<!-- Example: Technology stack requirements, compliance standards, deployment policies, etc. -->
+This principle exists to keep client, server, and design-system code predictable, navigable, and cheap to evolve.
 
-## [SECTION_3_NAME]
-<!-- Example: Development Workflow, Review Process, Quality Gates, etc. -->
+### III. Typed Contracts Over Ad-Hoc Behavior
+The repository is opinionated about typed contracts at every boundary.
 
-[SECTION_3_CONTENT]
-<!-- Example: Code review requirements, testing gates, deployment approval process, etc. -->
+- Client state, navigation, and expected failures MUST be modeled with typed constructs.
+- Server HTTP routes, DTOs, GraphQL models, and dependency failures MUST be expressed with explicit contract types and mappers.
+- UI design decisions MUST flow through design-system tokens and semantic themes, not raw implementation values.
+- Serialization and API surface decisions MUST be explicit and stable.
+
+This principle means the codebase prefers `Outcome`, `NavKey`, `NavigationIntent`, `@Resource`, `@Serializable`, `@SerialName`, gateway mappers, and `FreudDsToken` over strings, raw exceptions, ad-hoc route literals, or inline hard-coded visuals.
+
+### IV. Convention Plugins And Shared Infrastructure First
+Build, DI, HTTP client setup, health probing, and theme infrastructure MUST use the repository's shared mechanisms before custom alternatives are considered.
+
+- Gradle modules MUST use the existing convention plugins under `build-logic/`.
+- Shared Ktor, Koin, design-system, and Compose infrastructure MUST be reused.
+- New code MUST integrate with the repository's existing verification, serialization, health-check, and error-mapping infrastructure.
+- Heavy dependencies MUST NOT be added without explicit approval.
+
+This principle prevents configuration drift and preserves consistent behavior across platforms and services.
+
+### V. Verification Is Part Of The Definition Of Done
+No task is complete until the appropriate verification steps have been run for the paths changed, unless the user explicitly waives verification or the environment makes it impossible.
+
+- Client changes MUST be verified with `cd client && ./gradlew app:headwayAndroid:assembleDebug` and `cd client && ./gradlew detekt`.
+- Server changes MUST be verified with `cd server && ./gradlew build` and `cd server && ./gradlew detekt`.
+- Detekt failures are blocking; the repository treats static analysis as a quality gate, not as optional advice.
+- Tests SHOULD be added or updated when they materially reduce regression risk, when the user asks, or when nearby coverage patterns make the absence meaningful.
+- Broad or low-value tests that merely restate the implementation SHOULD be avoided.
+
+### VI. Simplicity, Safety, And Change Discipline
+The repository values focused diffs, reversible decisions, and clear reasons for complexity.
+
+- New complexity MUST be justified in the feature plan when a simpler alternative is rejected.
+- Existing patterns SHOULD be preferred over novel abstractions.
+- Secrets, environment values, and credentials MUST NOT be committed.
+- Destructive or irreversible repository actions MUST NOT be taken without explicit approval.
+- Placeholder implementations, silent shortcuts, and speculative rewrites MUST NOT be introduced.
+
+## Engineering Directives
+
+### Shared Kotlin Directives
+These directives apply across client and server Kotlin code unless a path-specific rule is stricter.
+
+- Use explicit imports; wildcard imports MUST NOT be used except `java.util.*` when truly necessary.
+- Multiline declarations and call sites MUST use trailing commas.
+- Named arguments SHOULD be used for calls with four or more arguments.
+- `asSequence()` SHOULD be used for three or more chained collection operations.
+- Expression bodies SHOULD be preferred for single-return functions.
+- Line length SHOULD remain under 120.
+- Functions SHOULD have at most six parameters; constructors SHOULD have at most seven.
+- Cyclomatic complexity SHOULD stay at or below 13.
+- Exhaustive `when` expressions on sealed types, enums, and booleans MUST NOT use `else`.
+- `TODO`, `FIXME`, `STOPSHIP`, `TODO()`, `NotImplementedError`, `println`, `print`, and `printStackTrace` MUST NOT appear in production code.
+- `!!` MUST NOT be used without a tightly proven invariant and no safer alternative.
+- `lateinit` MUST NOT be used unless there is no cleaner option and the requirement is explicit.
+- Functions that compute or map values SHOULD be named with verbs or `toTargetType` style conversions.
+- File-level `private const val` declarations SHOULD be placed at the bottom of the file.
+- Comments explaining code flow SHOULD NOT be added; KDoc is allowed for public APIs only.
+
+### Client Directives
+The client is a Kotlin Multiplatform Compose application with strict feature boundaries and MVIKotlin state management.
+
+#### Client module structure
+
+- New client features MUST use `feature/<name>/{api,di,internal}`.
+- `api` MUST contain only public contracts such as `NavKey` and route-holder contracts.
+- `di` MUST assemble Koin registrations.
+- `internal` MUST contain screens, stores, view models, route holders, and themes.
+- Feature implementation details SHOULD remain `internal`.
+
+#### Client state and behavior
+
+- MVIKotlin `Store` owns behavior; `ViewModel` MUST remain a thin bridge.
+- `Store` MUST define `Intent`, `State`, and `Label`.
+- `State` SHOULD be `@Immutable` and SHOULD provide default values for fields.
+- StoreFactory internals SHOULD use private `Action` and `Message` sealed interfaces where applicable.
+- ViewModel public methods MUST dispatch intents through `store.accept(...)`.
+- Business logic, branching workflow decisions, navigation policy, and state mutation logic MUST NOT live in `ViewModel`.
+- `collectAsStateWithLifecycle()` already provides the subscription; no-op `SideEffect` reads to keep collection alive MUST NOT be used.
+
+#### Client UI and design system
+
+- Feature UI MUST use the Freud design system, not raw Material3 or raw theme values.
+- Hard-coded colors, typography, spacing, and raw `Color` literals MUST NOT appear in feature UI.
+- Screens SHOULD use `FreudFallback` and `FreudScreenByWidth` where the established screen pattern expects them.
+- Composables that emit UI SHOULD expose a single `modifier: Modifier = Modifier`, applied to the root layout node.
+- `FreudText` MUST use the `value` parameter name, not `text`.
+- Boolean names SHOULD follow `isXxx`, `hasXxx`, `areXxx`, `canXxx`, or `shouldXxx`.
+- Android-only APIs MUST NOT be used in `commonMain`.
+
+#### Client navigation and errors
+
+- Navigation MUST go through `NavigatorContract` and `NavigationIntent`.
+- `NavKey` definitions MUST be serializable and stable.
+- Expected domain failures MUST be modeled with `Outcome`, not ad-hoc exceptions.
+- `CancellationException` MUST be rethrown.
+- `TimeoutCancellationException` MUST be handled according to the established `Outcome` wrappers rather than used as unchecked control flow.
+
+#### Compose stability
+
+- `@Immutable` models used in composition MUST use `ImmutableList`, `ImmutableMap`, or `ImmutableSet` for collection fields.
+- Stable collection wrappers MUST also contain stable element types.
+
+### Design-System Directives
+The design-system module is the source of truth for reusable UI primitives and tokens.
+
+- The module MUST remain reusable and MUST NOT absorb feature-specific business logic.
+- Public component APIs SHOULD accept `FreudDsToken<T>` for theme-driven colors, text styles, dimensions, and shapes.
+- Raw values MAY be resolved internally, but only as late as possible.
+- Dynamic token resolution SHOULD use the existing `provides` pattern and semantic theme mappings.
+- Helper objects, preview utilities, and construction glue SHOULD remain `internal` or `private`.
+- Components SHOULD keep internal defaults in a `private object XxxDefaults` unless a public default surface is intentionally required.
+- Public APIs SHOULD avoid leaking Material types unless they are truly part of the long-term contract.
+- Preview files SHOULD live under `component/preview` and SHOULD validate light and dark themes, key variants, and meaningful states.
+- Design-system spacing, shapes, and typography SHOULD be tokenized rather than expressed as raw literals.
+- Non-scaled typography behavior is currently a deliberate policy; any change to it MUST be treated as an API and design decision, not as an incidental tweak.
+
+### Server Directives
+The server is a multi-service Kotlin/JVM system built around Ktor microservices, a GraphQL gateway, Exposed, and shared infrastructure.
+
+#### Server module structure
+
+- Each microservice MUST preserve the `api` and `internal` split.
+- `api` modules define contracts only: DTOs, `@Resource` routes, URL holders, and other shared types.
+- `internal` modules define implementation only: routing, use cases, DI, repositories, configuration, mapping, and runtime assembly.
+- `gateway` is the single client-facing entry point and owns the public GraphQL contract.
+- Types inside `*/internal` MUST default to `internal`.
+- DTOs MUST NOT be duplicated across service `api` modules; owning `api` modules MUST be reused as dependencies.
+
+#### Server routing and layering
+
+- All HTTP paths MUST be defined with Ktor `@Resource` classes; raw string route literals are not allowed for contract paths.
+- All microservice routes MUST live under `/internal/v1/<service>`.
+- Every microservice MUST expose `/healthz` under its base URL.
+- Routing MUST remain thin and perform only basic validation such as `trim()`, `isBlank()`, and minimal format checks.
+- Business rules MUST live in use cases.
+- SQL and Exposed code MUST live in repositories or database helpers, not in use cases.
+- HTTP types and routing concerns MUST NOT leak into use cases.
+
+#### Server serialization and contracts
+
+- Wire DTOs MUST be `@Serializable`.
+- Serializable properties SHOULD be annotated with `@SerialName` using the actual wire key.
+- Shared serializers such as UUID and time serializers SHOULD be reused from `common`.
+- Gateway public models MUST remain separate from upstream service DTOs when contracts differ.
+- Contract mismatches MUST be resolved with mappers, not by ad-hoc mutation of upstream `api` types.
+
+#### Server dependency handling
+
+- Gateway outbound calls MUST use `upstreamCall(...)`.
+- Non-success upstream responses MUST be translated with the established gateway exception mapping.
+- New gateway repositories MUST NOT make raw `httpClient.get` or `httpClient.post` calls without `upstreamCall(...)`.
+- Downstream microservices called through dedicated Koin `HttpClient`s MUST have matching health probes wired into aggregated gateway health checks.
+
+#### Server error modeling
+
+- Service-specific domain exceptions SHOULD be sealed classes with explicit categories.
+- `DependencyUnavailable` MUST be used for unavailable or failing dependencies.
+- `UpstreamProtocol` MUST be used for unexpected upstream protocol or contract behavior.
+- New domain exceptions MUST be registered in the service's `StatusPages` handling.
+- Database-level expected business-rule rejections SHOULD be mapped to invalid-request style exceptions rather than collapsed into dependency outages.
+
+#### Server configuration and runtime
+
+- Environment behavior SHOULD branch through typed environment helpers rather than raw string comparisons.
+- Required environment values MUST fail fast when absent.
+- Secret validation MUST remain enforced in production paths.
+- Docker and runtime configuration changes are architectural changes and require explicit review.
+
+## Project Context And Approved Technical Baseline
+
+### Language And Platforms
+
+- Primary language: Kotlin 2.x.
+- Client platforms: Android, Desktop, iOS, and Web through Compose Multiplatform.
+- Server runtime: JVM 17 with Ktor and Netty.
+
+### Primary Frameworks And Infrastructure
+
+- Client: Compose Multiplatform, MVIKotlin, Koin, Navigation3, Freud design system, `Outcome`.
+- Server: Ktor, KGraphQL, Koin, Exposed, PostgreSQL, Docker.
+- Build: repository convention plugins under `build-logic/`.
+- Static analysis: Detekt everywhere, plus ktlint formatting and Compose lint on the client.
+
+### Repository Layout Expectations
+
+- `client/` contains application entries, shared composition roots, feature modules, navigation, DI, and design-system code.
+- `server/` contains microservices, the gateway, common infrastructure, migrations, Docker assets, and server build logic.
+- `.specify/` contains spec, plan, task, checklist, and agent templates for spec-driven delivery.
+- `.cursor/memory-bank/` captures current focus and stable cross-cutting patterns; it informs but does not supersede this constitution.
+
+## Development Workflow And Quality Gates
+
+### Constitution Check For Every Plan
+Every implementation plan MUST pass the following constitutional gate before research is considered complete, and MUST be re-checked after design decisions are made.
+
+1. The affected paths and governing rule sources are explicitly listed.
+2. The planned module structure matches repository conventions for those paths.
+3. The location of behavior is correct:
+   client Store vs ViewModel, server routing vs use case vs repository, design-system vs feature.
+4. Public and wire contracts are typed and explicit:
+   `NavKey`, `NavigationIntent`, `Outcome`, `@Resource`, `@Serializable`, `@SerialName`, mappers, probes, token APIs.
+5. The plan does not introduce prohibited shortcuts:
+   raw Material3 in feature UI, raw gateway HTTP calls, duplicated DTOs, string route literals, secret commits, placeholder implementations.
+6. The verification commands for the changed areas are named explicitly.
+7. Any required approval points are called out:
+   new dependencies, build-logic changes, navigation rewiring, design-system public API changes, Docker or env changes, schema changes.
+
+### Implementation Expectations
+
+- Prefer focused diffs over repository-wide rewrites.
+- Reuse established patterns before introducing new abstractions.
+- Keep build scripts minimal and convention-plugin driven.
+- Do not bypass team Detekt configuration with ad-hoc overrides unless the change itself is an approved build-policy update.
+- Do not silently widen public API surfaces.
+
+### Testing And Validation Expectations
+
+- Verification commands are mandatory quality gates, not optional housekeeping.
+- Add or update tests when they are the clearest way to protect behavior.
+- Avoid low-signal tests that add noise without meaningful regression protection.
+- If verification cannot be run, the blocker and the unverified risk MUST be recorded in the task result or review notes.
+
+## Exceptions, Complexity, And Amendments
+
+### Exception Policy
+Violations of this constitution are allowed only when they are explicit, necessary, and documented.
+
+- Any deliberate violation MUST be recorded in the plan's Complexity Tracking section.
+- The plan MUST name the violated rule, why it is necessary, and which simpler alternative was rejected.
+- Temporary exceptions SHOULD include a removal condition or migration path.
+- Convenience, time pressure, or personal preference are not sufficient justifications.
+
+### Amendment Policy
+This constitution MAY be amended when repository rules, architecture, or platform strategy changes materially.
+
+- Amendments MUST preserve alignment with the root `AGENTS.md`, path-specific `AGENTS.md` files, and active repository rules.
+- Amendments SHOULD be made together with any related rule or architecture updates so planning guidance and implementation guidance do not diverge.
+- Changes that alter public APIs, shared infrastructure, or policy-heavy behavior SHOULD be treated as versioned decisions.
 
 ## Governance
-<!-- Example: Constitution supersedes all other practices; Amendments require documentation, approval, migration plan -->
 
-[GOVERNANCE_RULES]
-<!-- Example: All PRs/reviews must verify compliance; Complexity must be justified; Use [GUIDANCE_FILE] for runtime development guidance -->
+This constitution supersedes default template assumptions in `.specify/` and is the required basis for `spec`, `plan`, `tasks`, and review quality gates in this repository.
 
-**Version**: [CONSTITUTION_VERSION] | **Ratified**: [RATIFICATION_DATE] | **Last Amended**: [LAST_AMENDED_DATE]
-<!-- Example: Version: 2.1.1 | Ratified: 2025-06-13 | Last Amended: 2025-07-16 -->
+Governance rules:
+
+- All implementation plans MUST include a Constitution Check derived from this file.
+- Reviewers and agents MUST reject work that violates mandatory principles without documented exceptions.
+- The closest path-specific rule set remains authoritative during implementation.
+- Memory Bank entries describe active context and stable patterns, but they do not grant permission to violate constitutional rules.
+- Lessons captured in `.cursor/rules/lessons-learned.mdc` are considered cumulative anti-pattern guidance and SHOULD inform future planning and review.
+
+**Version**: 1.0.0 | **Ratified**: 2026-04-08 | **Last Amended**: 2026-04-08

--- a/client/.run/headway-android.run.xml
+++ b/client/.run/headway-android.run.xml
@@ -13,7 +13,7 @@
     <option name="CLEAR_APP_STORAGE" value="false" />
     <option name="DYNAMIC_FEATURES_DISABLED_LIST" value="" />
     <option name="ACTIVITY_EXTRA_FLAGS" value="" />
-    <option name="MODE" value="default_activity" />
+    <option name="MODE" value="specific_activity" />
     <option name="RESTORE_ENABLED" value="false" />
     <option name="RESTORE_FILE" value="" />
     <option name="RESTORE_FRESH_INSTALL_ONLY" value="false" />
@@ -63,8 +63,8 @@
       <option name="NATIVE_MEMORY_SAMPLE_RATE_BYTES" value="2048" />
     </Profilers>
     <option name="DEEP_LINK" value="" />
-    <option name="ACTIVITY" value="" />
-    <option name="ACTIVITY_CLASS" value="" />
+    <option name="ACTIVITY" value="dev.kigya.headway.MainActivity" />
+    <option name="ACTIVITY_CLASS" value="dev.kigya.headway.MainActivity" />
     <option name="SEARCH_ACTIVITY_IN_GLOBAL_SCOPE" value="false" />
     <option name="SKIP_ACTIVITY_VALIDATION" value="false" />
     <method v="2">

--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -13,7 +13,7 @@ For the design system see [`core/design-system/.../AGENTS.md`](core/design-syste
 | Language        | Kotlin 2.x, KMP (commonMain + androidMain / iosMain / desktopMain / wasmJsMain)         |
 | UI              | Compose Multiplatform (Android / Desktop / iOS / Web)                                   |
 | State           | MVIKotlin (Store + Intent / State / Label / Action / Message)                           |
-| DI              | Koin Multiplatform, `KoinMultiplatformApplication`                                      |
+| DI              | Koin Multiplatform, `KoinApplication`                                                   |
 | Navigation      | Navigation3 (`NavDisplay`, `NavKey`, `entryProvider`)                                   |
 | Error handling  | `Outcome<Error, Value>` (`core:outcome`)                                                |
 | Design system   | `core:design-system` — `FreudTheme`, `FreudDsToken<T>`, `FreudColorScheme`              |
@@ -32,7 +32,7 @@ cd client && ./gradlew app:headwayAndroid:assembleDebug
 cd client && ./gradlew detekt
 
 # Build a single module
-cd client && ./gradlew :feature:auth:internal:compileKotlinAndroid
+cd client && ./gradlew :feature:auth-internal:compileKotlinAndroid
 
 # Full project build (when explicitly requested)
 cd client && ./gradlew build
@@ -51,7 +51,7 @@ client/
 │   ├── headwayDesktop/         # Desktop (JVM) application entry point
 │   ├── headwayIOS/             # iOS application entry point (via shared)
 │   └── headwayWeb/             # WasmJs application entry point
-├── shared/                     # App.kt — KoinMultiplatformApplication + FreudTheme + NavDisplay
+├── shared/                     # App.kt — KoinApplication + FreudTheme + NavDisplay
 ├── core/
 │   ├── annotation/             # @MarkerInterface and other shared annotations
 │   ├── design-system/          # FreudTheme, tokens, components, previews (see dedicated AGENTS.md)
@@ -294,7 +294,7 @@ Rules:
 - `ViewModel` is registered via `viewModelOf`
 - `RouteHolder` is registered via `singleOf` with `bind Contract::class`
 - Feature modules are aggregated in `di/modules` → `featureModules` list
-- App entry uses `KoinMultiplatformApplication(config = KoinConfiguration { modules(appModules) })`
+- App entry uses `KoinApplication(configuration = KoinConfiguration { modules(appModules) }, content = …)`
 
 ---
 
@@ -398,5 +398,5 @@ Rules:
 3. **`feature/<name>/di`** — create `val <name>Module get() = module { ... }` with StoreFactory, ViewModel, RouteHolder
 4. **`di/modules`** — add module to `featureModules` list
 5. **`shared/App.kt`** — add `entry<ScreenKey> { routeHolder.content() }` to `entryProvider`
-6. **`settings.gradle.kts`** — include `:feature:<name>:api`, `:feature:<name>:internal`, `:feature:<name>:di`
+6. **`settings.gradle.kts`** — register `feature:<name>-api|-internal|-di` with `projectDir` under `feature/<name>/…`; same idea for `navigation:navigation-*` → `navigation/…` and `di:di-*` → `di/…`
 7. **Verify** — run `./gradlew app:headwayAndroid:assembleDebug` and `./gradlew detekt`

--- a/client/app/headwayAndroid/build.gradle.kts
+++ b/client/app/headwayAndroid/build.gradle.kts
@@ -14,6 +14,12 @@ configureAndroidApplication {
 
 dependencies {
     projects {
+        implementation(core.outcome)
+        implementation(core.sessionInternal)
+        implementation(di.diModules)
         implementation(shared)
+    }
+    libs {
+        implementation(koin.android)
     }
 }

--- a/client/app/headwayAndroid/src/androidMain/AndroidManifest.xml
+++ b/client/app/headwayAndroid/src/androidMain/AndroidManifest.xml
@@ -2,12 +2,20 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name="dev.kigya.headway.HeadwayApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <meta-data
+            android:name="headway.graphql.httpUrl"
+            android:value="${headwayGraphqlHttpUrl}" />
+        <meta-data
+            android:name="headway.google.webClientId"
+            android:value="@string/google_web_client_id" />
         <activity
             android:name="dev.kigya.headway.MainActivity"
             android:exported="true">

--- a/client/app/headwayAndroid/src/androidMain/kotlin/dev/kigya/headway/HeadwayApp.kt
+++ b/client/app/headwayAndroid/src/androidMain/kotlin/dev/kigya/headway/HeadwayApp.kt
@@ -1,5 +1,20 @@
 package dev.kigya.headway
 
 import android.app.Application
+import dev.kigya.headway.core.session.android.google.headwayAndroidSessionGoogleModule
+import dev.kigya.headway.di.api.appModules
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.core.context.startKoin
+import org.koin.core.logger.Level
 
-class HeadwayApp : Application()
+class HeadwayApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        startKoin {
+            androidLogger(Level.ERROR)
+            androidContext(this@HeadwayApp)
+            modules(listOf(headwayAndroidSessionGoogleModule()) + appModules)
+        }
+    }
+}

--- a/client/app/headwayAndroid/src/androidMain/kotlin/dev/kigya/headway/MainActivity.kt
+++ b/client/app/headwayAndroid/src/androidMain/kotlin/dev/kigya/headway/MainActivity.kt
@@ -3,10 +3,24 @@ package dev.kigya.headway
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import dev.kigya.headway.core.session.android.google.HeadwayAndroidGoogleSignInBridge
+import dev.kigya.headway.core.session.android.google.HeadwayAndroidGoogleSignInFlow
+import org.koin.android.ext.android.inject
 
 internal class MainActivity : ComponentActivity() {
+
+    private val googleSignInBridge: HeadwayAndroidGoogleSignInBridge by inject()
+    private val googleSignInFlow = HeadwayAndroidGoogleSignInFlow(this)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        googleSignInBridge.attach(googleSignInFlow)
         setContent { App() }
+    }
+
+    override fun onDestroy() {
+        googleSignInFlow.onDestroy()
+        googleSignInBridge.detach(googleSignInFlow)
+        super.onDestroy()
     }
 }

--- a/client/app/headwayAndroid/src/androidMain/res/values/strings.xml
+++ b/client/app/headwayAndroid/src/androidMain/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name" translatable="false">Headway</string>
+    <string name="google_web_client_id" translatable="false">658272377808-alf63nc9km4tjgv0dr6lltfqfo1jshqb.apps.googleusercontent.com</string>
 </resources>

--- a/client/app/headwayAndroid/src/androidMain/res/xml/network_security_config.xml
+++ b/client/app/headwayAndroid/src/androidMain/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/client/app/headwayDesktop/src/desktopMain/kotlin/dev/kigya/headway/Main.kt
+++ b/client/app/headwayDesktop/src/desktopMain/kotlin/dev/kigya/headway/Main.kt
@@ -1,16 +1,28 @@
 package dev.kigya.headway
 
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Tray
 import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
+import androidx.compose.ui.window.rememberWindowState
 import headway.app.headwaydesktop.generated.resources.Res
 import headway.app.headwaydesktop.generated.resources.app_name
 import headway.app.headwaydesktop.generated.resources.ic_headway_tray
 import headway.app.headwaydesktop.generated.resources.tray_quit_app
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import java.awt.Dimension
 
 fun main() = application {
+    val windowState = rememberWindowState(
+        position = WindowPosition.Aligned(Alignment.Center),
+        width = defaultWindowWidth,
+        height = defaultWindowHeight,
+    )
     Tray(
         icon = painterResource(Res.drawable.ic_headway_tray),
         menu = {
@@ -23,8 +35,21 @@ fun main() = application {
 
     Window(
         onCloseRequest = ::exitApplication,
+        state = windowState,
         title = stringResource(Res.string.app_name),
     ) {
+        val density = LocalDensity.current
+        SideEffect {
+            window.minimumSize = Dimension(
+                with(density) { minimumWindowWidth.roundToPx() }.coerceAtLeast(1),
+                with(density) { minimumWindowHeight.roundToPx() }.coerceAtLeast(1),
+            )
+        }
         App()
     }
 }
+
+private val defaultWindowWidth = 600.dp
+private val defaultWindowHeight = 400.dp
+private val minimumWindowWidth = 600.dp
+private val minimumWindowHeight = 400.dp

--- a/client/app/headwayIOS/GoogleService-Info.plist
+++ b/client/app/headwayIOS/GoogleService-Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CLIENT_ID</key>
-	<string>932009275652-ov0q9ii92dd3domj8sk7aosth7k42cdg.apps.googleusercontent.com</string>
+	<string>658272377808-d617os8k1vmam7rul9fnamj32cbsebaa.apps.googleusercontent.com</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.932009275652-ov0q9ii92dd3domj8sk7aosth7k42cdg</string>
+	<string>com.googleusercontent.apps.658272377808-d617os8k1vmam7rul9fnamj32cbsebaa</string>
 	<key>API_KEY</key>
 	<string>AIzaSyAhQJ6LK9Ve8uNbIErgKItZuEs5CEkzyNc</string>
 	<key>GCM_SENDER_ID</key>

--- a/client/app/headwayIOS/headwayIOS/Info.plist
+++ b/client/app/headwayIOS/headwayIOS/Info.plist
@@ -4,5 +4,16 @@
 <dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.658272377808-d617os8k1vmam7rul9fnamj32cbsebaa</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/client/app/headwayIOS/headwayIOS/iOSApp.swift
+++ b/client/app/headwayIOS/headwayIOS/iOSApp.swift
@@ -2,6 +2,17 @@ import SwiftUI
 import GoogleSignIn
 import shared
 import Firebase
+import UIKit
+
+private let headwayGoogleServerClientId =
+    "658272377808-alf63nc9km4tjgv0dr6lltfqfo1jshqb.apps.googleusercontent.com"
+
+private let headwayGoogleIosClientId =
+    "658272377808-d617os8k1vmam7rul9fnamj32cbsebaa.apps.googleusercontent.com"
+
+private let headwayGoogleSignInNsErrorDomain = "com.google.GIDSignIn"
+
+private let headwayGoogleSignInCanceledErrorCode: Int = -5
 
 @main
 struct HeadwayIOS: App {
@@ -10,6 +21,11 @@ struct HeadwayIOS: App {
     
     init() {
         FirebaseApp.configure()
+        IosGoogleSignInBridgeKt.headwayIosRegisterGoogleSignInRunner {
+            DispatchQueue.main.async {
+                headwayPresentGoogleSignInFromKotlin()
+            }
+        }
     }
 
     var body: some Scene {
@@ -18,5 +34,40 @@ struct HeadwayIOS: App {
                 GIDSignIn.sharedInstance.handle(url)
             }
         }
+    }
+}
+
+private func headwayPresentGoogleSignInFromKotlin() {
+    guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+        IosGoogleSignInBridgeKt.headwayIosOnGoogleSignInUnavailable()
+        return
+    }
+    let root = scene.windows.first(where: { $0.isKeyWindow })?.rootViewController
+        ?? scene.windows.first?.rootViewController
+    guard let presenter = root else {
+        IosGoogleSignInBridgeKt.headwayIosOnGoogleSignInUnavailable()
+        return
+    }
+    let configuration = GIDConfiguration(
+        clientID: headwayGoogleIosClientId,
+        serverClientID: headwayGoogleServerClientId,
+    )
+    GIDSignIn.sharedInstance.configuration = configuration
+    GIDSignIn.sharedInstance.signIn(withPresenting: presenter) { result, error in
+        if let error {
+            let nsError = error as NSError
+            if nsError.domain == headwayGoogleSignInNsErrorDomain,
+               nsError.code == headwayGoogleSignInCanceledErrorCode {
+                IosGoogleSignInBridgeKt.headwayIosOnGoogleSignInUserCancelled()
+            } else {
+                IosGoogleSignInBridgeKt.headwayIosOnGoogleSignInUnavailable()
+            }
+            return
+        }
+        guard let token = result?.user.idToken?.tokenString, !token.isEmpty else {
+            IosGoogleSignInBridgeKt.headwayIosOnGoogleSignInUnavailable()
+            return
+        }
+        IosGoogleSignInBridgeKt.headwayIosOnGoogleSignInSuccess(idToken: token)
     }
 }

--- a/client/app/headwayWeb/src/wasmJsMain/resources/headway-google.js
+++ b/client/app/headwayWeb/src/wasmJsMain/resources/headway-google.js
@@ -1,0 +1,66 @@
+(function () {
+    window.headwayStartGoogleCredentialFlow = function (clientId) {
+        return new Promise(function (resolve, reject) {
+            function fail(message) {
+                reject(new Error(message));
+            }
+            function begin() {
+                if (!window.google || !google.accounts || !google.accounts.id) {
+                    fail('gsi_not_loaded');
+                    return;
+                }
+                var settled = false;
+                function finishOk(cred) {
+                    if (settled) {
+                        return;
+                    }
+                    settled = true;
+                    resolve(cred);
+                }
+                function finishFail(msg) {
+                    if (settled) {
+                        return;
+                    }
+                    settled = true;
+                    fail(msg);
+                }
+                google.accounts.id.initialize({
+                    client_id: clientId,
+                    callback: function (resp) {
+                        if (resp && resp.credential) {
+                            finishOk(resp.credential);
+                        } else {
+                            finishFail('no_credential');
+                        }
+                    },
+                    auto_select: false,
+                });
+                var div = document.createElement('div');
+                div.style.position = 'fixed';
+                div.style.left = '-9999px';
+                div.style.top = '0';
+                div.style.opacity = '0';
+                document.body.appendChild(div);
+                google.accounts.id.renderButton(div, {
+                    type: 'standard',
+                    theme: 'outline',
+                    size: 'large',
+                    text: 'signin_with',
+                });
+                window.setTimeout(function () {
+                    var btn = div.querySelector('div[role="button"]');
+                    if (btn && typeof btn.click === 'function') {
+                        btn.click();
+                    } else {
+                        finishFail('no_google_button');
+                    }
+                }, 500);
+            }
+            if (document.readyState === 'complete') {
+                begin();
+            } else {
+                window.addEventListener('load', begin);
+            }
+        });
+    };
+})();

--- a/client/app/headwayWeb/src/wasmJsMain/resources/index.html
+++ b/client/app/headwayWeb/src/wasmJsMain/resources/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Headway</title>
     <link type="text/css" rel="stylesheet" href="styles.css">
+    <script async defer src="https://accounts.google.com/gsi/client"></script>
+    <script defer src="headway-google.js"></script>
     <script type="application/javascript" src="headwayApp.js"></script>
 </head>
 <body>

--- a/client/build-logic/base/src/main/kotlin/base.webApplication.gradle.kts
+++ b/client/build-logic/base/src/main/kotlin/base.webApplication.gradle.kts
@@ -1,10 +1,9 @@
+@file:OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
+
 import base.WebApplicationConventionParams
 import org.gradle.kotlin.dsl.configure
-import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
-import kotlin.apply
-import kotlin.jvm.java
 
 plugins {
     id("org.jetbrains.kotlin.multiplatform")
@@ -28,6 +27,7 @@ project.afterEvaluate {
                 commonWebpackConfig {
                     outputFileName = "${name}App.js"
                     devServer = (devServer ?: KotlinWebpackConfig.DevServer()).apply {
+                        port = webExtension.port.get()
                         static = (static ?: mutableListOf()).apply {
                             add(rootDirPath)
                             add(projectDirPath)

--- a/client/build-logic/base/src/main/kotlin/internal.config.android.gradle.kts
+++ b/client/build-logic/base/src/main/kotlin/internal.config.android.gradle.kts
@@ -13,11 +13,15 @@ val androidExtension = project.extensions.create(
 
 androidExtension.namespace.convention(
     project.provider {
-        val projectNameFormatted = project.path
-            .drop(1)
-            .replace(Regex("[-:]"), ".")
-        "dev.kigya.headway.$projectNameFormatted"
-    }
+        if (project.path == ":app:headwayAndroid") {
+            "dev.kigya.headway"
+        } else {
+            val projectNameFormatted = project.path
+                .drop(1)
+                .replace(Regex("[-:]"), ".")
+            "dev.kigya.headway.$projectNameFormatted"
+        }
+    },
 )
 
 /**
@@ -37,6 +41,7 @@ configureIfExists(ApplicationExtension::class.java) {
         versionCode = androidExtension.versionCode.get()
         versionName = androidExtension.versionName.get()
         resourceConfigurations += androidExtension.resourceConfigurations.get()
+        manifestPlaceholders["headwayGraphqlHttpUrl"] = androidExtension.headwayGraphqlHttpUrl.get()
 
         testOptions.unitTests.apply {
             isIncludeAndroidResources = true

--- a/client/build-logic/gradle-extension/src/main/kotlin/base/AndroidApplicationConventionParams.kt
+++ b/client/build-logic/gradle-extension/src/main/kotlin/base/AndroidApplicationConventionParams.kt
@@ -60,6 +60,6 @@ public abstract class AndroidApplicationConventionParams @Inject constructor(
         versionCode.convention(1)
         versionName.convention("1.0.0")
         resourceConfigurations.convention(emptyList())
-        headwayGraphqlHttpUrl.convention("http://10.0.2.2:8080/api/v1/graphql")
+        headwayGraphqlHttpUrl.convention("https://kigya-headway-dev-gateway.onrender.com/api/v1/graphql")
     }
 }

--- a/client/build-logic/gradle-extension/src/main/kotlin/base/AndroidApplicationConventionParams.kt
+++ b/client/build-logic/gradle-extension/src/main/kotlin/base/AndroidApplicationConventionParams.kt
@@ -33,6 +33,10 @@ import org.gradle.api.tasks.Input
  * @property resourceConfigurations
  *   List of resource qualifiers to include (e.g. `["ru","en"]`).
  *   Defaults to an empty list.
+ *
+ * @property headwayGraphqlHttpUrl
+ *   Value for manifest placeholder `headwayGraphqlHttpUrl` (GraphQL HTTP URL; default targets the
+ *   host loopback from the Android emulator via `10.0.2.2`).
  */
 public abstract class AndroidApplicationConventionParams @Inject constructor(
     objects: ObjectFactory,
@@ -49,9 +53,13 @@ public abstract class AndroidApplicationConventionParams @Inject constructor(
     @get:Input
     public abstract val resourceConfigurations: ListProperty<String>
 
+    @get:Input
+    public abstract val headwayGraphqlHttpUrl: Property<String>
+
     init {
         versionCode.convention(1)
         versionName.convention("1.0.0")
         resourceConfigurations.convention(emptyList())
+        headwayGraphqlHttpUrl.convention("http://10.0.2.2:8080/api/v1/graphql")
     }
 }

--- a/client/build-logic/gradle-extension/src/main/kotlin/base/WebApplicationConventionParams.kt
+++ b/client/build-logic/gradle-extension/src/main/kotlin/base/WebApplicationConventionParams.kt
@@ -5,13 +5,25 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import javax.inject.Inject
 
+/**
+ * Parameters for the web (wasmJs browser) application convention plugin.
+ *
+ * @property name
+ *   Short app name used for webpack `outputFileName` / `outputModuleName` (lowercased in the plugin).
+ * @property port
+ *   Dev server port for `KotlinWebpackConfig.DevServer`.
+ */
 public abstract class WebApplicationConventionParams @Inject constructor(
     objects: ObjectFactory,
 ) {
     @get:Input
     public abstract val name: Property<String>
 
+    @get:Input
+    public abstract val port: Property<Int>
+
     init {
         name.convention("")
+        port.convention(8765)
     }
 }

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
     alias(libs.plugins.serialization) apply false
     alias(libs.plugins.room) apply false
     alias(libs.plugins.buildkonfig) apply false
+    alias(libs.plugins.apollo) apply false
 }
 
 buildscript {

--- a/client/core/apollo/build.gradle.kts
+++ b/client/core/apollo/build.gradle.kts
@@ -1,0 +1,24 @@
+import extension.commonMainDependencies
+
+plugins {
+    alias(libs.plugins.convention.base.sharedLibrary)
+    alias(libs.plugins.convention.component.serialization)
+    alias(libs.plugins.apollo)
+}
+
+apollo {
+    service("headway") {
+        packageName.set("dev.kigya.headway.core.apollo.generated")
+        mapScalarToKotlinLong("Long")
+        schemaFiles.from(file("src/commonMain/graphql/schema.graphqls"))
+    }
+}
+
+commonMainDependencies {
+    projects {
+        implementation(core.networkApi)
+    }
+    libs {
+        implementation(apollo.runtime)
+    }
+}

--- a/client/core/apollo/src/commonMain/graphql/HomeScreen.graphql
+++ b/client/core/apollo/src/commonMain/graphql/HomeScreen.graphql
@@ -1,0 +1,16 @@
+query HomeScreen {
+    homeScreen {
+        dateLabel
+        greeting
+        roleLabel
+        readinessPercent
+        nextInterviewType
+        nextInterviewTypeLabel
+        sections {
+            id
+            title
+            style
+            iconUrl
+        }
+    }
+}

--- a/client/core/apollo/src/commonMain/graphql/LearningQuestionsCatalog.graphql
+++ b/client/core/apollo/src/commonMain/graphql/LearningQuestionsCatalog.graphql
@@ -1,0 +1,16 @@
+query LearningQuestionsCatalog($subjectUserId: UUID) {
+    learningQuestionsCatalog(subjectUserId: $subjectUserId) {
+        hardSkills {
+            id
+            text
+            skillGroup
+        }
+        softSkills {
+            id
+            text
+            skillGroup
+        }
+        resumeHard
+        resumeSoft
+    }
+}

--- a/client/core/apollo/src/commonMain/graphql/LoginAsGuest.graphql
+++ b/client/core/apollo/src/commonMain/graphql/LoginAsGuest.graphql
@@ -1,0 +1,6 @@
+mutation LoginAsGuest($stub: Boolean) {
+    loginAsGuest(stub: $stub) {
+        accessToken
+        expiresAtEpochMs
+    }
+}

--- a/client/core/apollo/src/commonMain/graphql/LoginWithGoogle.graphql
+++ b/client/core/apollo/src/commonMain/graphql/LoginWithGoogle.graphql
@@ -1,0 +1,11 @@
+mutation LoginWithGoogle($idToken: String!, $fingerprint: String!, $platform: GatewaySessionPlatform!) {
+    loginWithGoogle(idToken: $idToken, fingerprint: $fingerprint, platform: $platform) {
+        accessToken
+        refreshToken
+        user {
+            id
+            email
+            name
+        }
+    }
+}

--- a/client/core/apollo/src/commonMain/graphql/LogoutGuest.graphql
+++ b/client/core/apollo/src/commonMain/graphql/LogoutGuest.graphql
@@ -1,0 +1,3 @@
+mutation LogoutGuest {
+    logoutGuest
+}

--- a/client/core/apollo/src/commonMain/graphql/RefreshToken.graphql
+++ b/client/core/apollo/src/commonMain/graphql/RefreshToken.graphql
@@ -1,0 +1,5 @@
+mutation RefreshToken($refreshToken: String!, $fingerprint: String!) {
+    refreshToken(refreshToken: $refreshToken, fingerprint: $fingerprint) {
+        accessToken
+    }
+}

--- a/client/core/apollo/src/commonMain/graphql/schema.graphqls
+++ b/client/core/apollo/src/commonMain/graphql/schema.graphqls
@@ -1,0 +1,137 @@
+scalar UUID
+scalar Long
+
+schema {
+    query: Query
+    mutation: Mutation
+}
+
+type Query {
+    homeScreen: HomeScreenPayload!
+    learningQuestionsCatalog(subjectUserId: UUID): GatewayLearningQuestionsCatalog!
+}
+
+type Mutation {
+    loginWithGoogle(idToken: String!, fingerprint: String!, platform: GatewaySessionPlatform!): GatewayGoogleLoginResponse!
+    loginAsGuest(stub: Boolean): GatewayGuestLoginResponse!
+    refreshToken(refreshToken: String!, fingerprint: String!): GatewayRefreshAccessTokenResponse!
+    logoutGuest: Boolean!
+}
+
+enum GatewaySessionPlatform {
+    ANDROID
+    IOS
+    DESKTOP
+    WEB
+}
+
+type GatewayGoogleLoginResponse {
+    accessToken: String!
+    refreshToken: String!
+    user: GatewayUser!
+}
+
+type GatewayUser {
+    id: UUID!
+    email: String!
+    name: String!
+    role: GatewayUserRole!
+    avatarUrl: String
+    department: GatewayUserDepartment
+    is_active: Boolean!
+}
+
+enum GatewayUserRole {
+    DEVELOPER
+    MANAGER
+    MENTOR
+    EMPLOYEE
+    GUEST
+}
+
+enum GatewayUserDepartment {
+    ANDROID
+    IOS
+    CROSS_PLATFORM
+}
+
+type GatewayGuestLoginResponse {
+    accessToken: String!
+    expiresAtEpochMs: Long!
+}
+
+type GatewayRefreshAccessTokenResponse {
+    accessToken: String!
+}
+
+type HomeScreenPayload {
+    dateLabel: String!
+    greeting: String!
+    roleLabel: String
+    readinessPercent: Int
+    nextInterviewType: HomeScreenNextInterviewType
+    nextInterviewTypeLabel: String
+    sections: [HomeScreenSectionItem!]!
+}
+
+enum HomeScreenNextInterviewType {
+    CHECK
+    SPOT
+    MOCK
+    SOFT_SKILLS
+}
+
+type HomeScreenSectionItem {
+    id: HomeScreenSectionId!
+    title: String!
+    style: HomeScreenSectionStyle!
+    iconUrl: String!
+}
+
+enum HomeScreenSectionId {
+    HOME
+    START_TRAINING_SESSION
+    LEARN_QUESTIONS
+    EMPLOYEE_PROGRESS_MANAGEMENT
+    PEOPLE_MANAGEMENT
+    VIEW_STATISTICS
+    ABOUT
+    SIGN_OUT
+}
+
+enum HomeScreenSectionStyle {
+    FILLED_PRIMARY
+    OUTLINED_ACCENT
+    DEFAULT
+}
+
+type GatewayLearningQuestionsCatalog {
+    hardSkills: [GatewayLearningQuestion!]!
+    softSkills: [GatewayLearningQuestion!]!
+    resumeHard: Long
+    resumeSoft: Long
+}
+
+type GatewayLearningQuestion {
+    id: Long!
+    skillGroup: GatewayLearningSkillGroup!
+    text: String!
+    tags: [GatewayLearningTag!]!
+    progress: GatewayLearningProgressState
+}
+
+enum GatewayLearningSkillGroup {
+    HARD
+    SOFT
+}
+
+enum GatewayLearningProgressState {
+    NOT_ANSWERED
+    PARTIALLY_ANSWERED
+    ANSWERED
+}
+
+type GatewayLearningTag {
+    id: Long!
+    label: String!
+}

--- a/client/core/apollo/src/commonMain/kotlin/dev/kigya/headway/core/apollo/HeadwayAccessTokenHolder.kt
+++ b/client/core/apollo/src/commonMain/kotlin/dev/kigya/headway/core/apollo/HeadwayAccessTokenHolder.kt
@@ -1,0 +1,17 @@
+package dev.kigya.headway.core.apollo
+
+import dev.kigya.headway.core.network.api.HeadwayAccessTokenStore
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+@OptIn(ExperimentalAtomicApi::class)
+class HeadwayAccessTokenHolder : HeadwayAccessTokenStore {
+
+    private val tokenRef = AtomicReference<String?>(null)
+
+    override fun current(): String? = tokenRef.load()
+
+    override fun update(value: String?) {
+        tokenRef.store(value)
+    }
+}

--- a/client/core/apollo/src/commonMain/kotlin/dev/kigya/headway/core/apollo/HeadwayApolloClientFactory.kt
+++ b/client/core/apollo/src/commonMain/kotlin/dev/kigya/headway/core/apollo/HeadwayApolloClientFactory.kt
@@ -1,0 +1,124 @@
+package dev.kigya.headway.core.apollo
+
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.http.HttpRequest
+import com.apollographql.apollo.api.http.HttpResponse
+import com.apollographql.apollo.network.http.HttpInterceptor
+import com.apollographql.apollo.network.http.HttpInterceptorChain
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import okio.Buffer
+
+fun createHeadwayApolloClient(
+    serverUrl: String,
+    accessTokenProvider: () -> String?,
+): ApolloClient {
+    val builder = ApolloClient.Builder()
+        .serverUrl(serverUrl)
+        .addHttpInterceptor(
+            HeadwayGraphQlStripNestedDataExtensionsHttpInterceptor(),
+        )
+        .addHttpInterceptor(
+            BearerAuthorizationHttpInterceptor(accessTokenProvider),
+        )
+    return builder.build()
+}
+
+private class HeadwayGraphQlStripNestedDataExtensionsHttpInterceptor : HttpInterceptor {
+
+    override suspend fun intercept(
+        request: HttpRequest,
+        chain: HttpInterceptorChain,
+    ): HttpResponse {
+        val response = chain.proceed(request)
+        val source = response.body ?: return response
+        val text = try {
+            source.readUtf8()
+        } catch (_: Throwable) {
+            return response
+        } finally {
+            runCatching { source.close() }
+        }
+        val rewritten = rewriteGraphQlJsonWithoutExtensionsUnderData(text)
+        return HttpResponse.Builder(statusCode = response.statusCode)
+            .apply {
+                addHeaders(response.headers)
+                body(Buffer().writeUtf8(rewritten))
+            }
+            .build()
+    }
+}
+
+private fun rewriteGraphQlJsonWithoutExtensionsUnderData(text: String): String {
+    val root = runCatching {
+        headwayGraphQlHttpJson.parseToJsonElement(text).jsonObject
+    }.getOrNull() ?: return text
+    val dataElement = root[HEADWAY_GRAPHQL_JSON_KEY_DATA] ?: return text
+    val dataObject = dataElement.asJsonObjectOrNull() ?: return text
+    var changed = false
+    val newDataObject = buildJsonObject {
+        dataObject.forEach { (fieldKey, fieldElement) ->
+            val fieldJsonObject = fieldElement.asJsonObjectOrNull()
+            if (fieldJsonObject != null && fieldJsonObject.containsKey(HEADWAY_GRAPHQL_JSON_KEY_EXTENSIONS)) {
+                changed = true
+                put(
+                    fieldKey,
+                    buildJsonObject {
+                        fieldJsonObject.forEach { (nestedKey, nestedValue) ->
+                            if (nestedKey != HEADWAY_GRAPHQL_JSON_KEY_EXTENSIONS) {
+                                put(nestedKey, nestedValue)
+                            }
+                        }
+                    },
+                )
+            } else {
+                put(fieldKey, fieldElement)
+            }
+        }
+    }
+    if (!changed) {
+        return text
+    }
+    val outRoot = buildJsonObject {
+        root.forEach { (topKey, topValue) ->
+            if (topKey == HEADWAY_GRAPHQL_JSON_KEY_DATA) {
+                put(topKey, newDataObject)
+            } else {
+                put(topKey, topValue)
+            }
+        }
+    }
+    return headwayGraphQlHttpJson.encodeToString(outRoot)
+}
+
+private fun JsonElement.asJsonObjectOrNull(): JsonObject? = this as? JsonObject
+
+private val headwayGraphQlHttpJson: Json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+}
+
+private class BearerAuthorizationHttpInterceptor(
+    private val accessTokenProvider: () -> String?,
+) : HttpInterceptor {
+
+    override suspend fun intercept(
+        request: HttpRequest,
+        chain: HttpInterceptorChain,
+    ): HttpResponse {
+        val token = accessTokenProvider()
+        val authorized = if (token.isNullOrBlank()) {
+            request
+        } else {
+            request.newBuilder().addHeader("Authorization", "Bearer $token").build()
+        }
+        return chain.proceed(authorized)
+    }
+}
+
+private const val HEADWAY_GRAPHQL_JSON_KEY_DATA: String = "data"
+
+private const val HEADWAY_GRAPHQL_JSON_KEY_EXTENSIONS: String = "extensions"

--- a/client/core/apollo/src/commonMain/kotlin/dev/kigya/headway/core/apollo/HeadwayGraphqlExecutor.kt
+++ b/client/core/apollo/src/commonMain/kotlin/dev/kigya/headway/core/apollo/HeadwayGraphqlExecutor.kt
@@ -1,0 +1,103 @@
+package dev.kigya.headway.core.apollo
+
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.ApolloResponse
+import com.apollographql.apollo.api.Mutation
+import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.exception.ApolloHttpException
+import com.apollographql.apollo.exception.ApolloNetworkException
+import dev.kigya.headway.core.network.api.HeadwayGraphqlOperationExecutor
+import dev.kigya.headway.core.network.api.HeadwayRemoteGraphqlFailure
+import dev.kigya.headway.core.outcome.Outcome
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlin.coroutines.cancellation.CancellationException
+
+class HeadwayGraphqlExecutor(
+    private val apolloClient: ApolloClient,
+) : HeadwayGraphqlOperationExecutor {
+
+    override suspend fun <D : Query.Data> executeQuery(
+        query: Query<D>,
+    ): Outcome<HeadwayRemoteGraphqlFailure, D> =
+        runCatching { apolloClient.query(query).execute() }.foldApolloResponse()
+
+    override suspend fun <D : Mutation.Data> executeMutation(
+        mutation: Mutation<D>,
+    ): Outcome<HeadwayRemoteGraphqlFailure, D> =
+        runCatching { apolloClient.mutation(mutation).execute() }.foldApolloResponse()
+
+    private fun <D : Operation.Data> Result<ApolloResponse<D>>.foldApolloResponse():
+        Outcome<HeadwayRemoteGraphqlFailure, D> =
+        fold(
+            onSuccess = { response -> response.toOutcome() },
+            onFailure = { throwable ->
+                when (throwable) {
+                    is TimeoutCancellationException -> Outcome.failure(HeadwayRemoteGraphqlFailure.UnexpectedResponse)
+                    is CancellationException -> throw throwable
+                    else -> Outcome.failure(mapFailure(throwable))
+                }
+            },
+        )
+
+    private fun <D : Operation.Data> ApolloResponse<D>.toOutcome(): Outcome<HeadwayRemoteGraphqlFailure, D> {
+        val failureException = exception
+        if (failureException != null) {
+            return Outcome.failure(mapFailure(failureException))
+        }
+        val successData = data
+        if (successData != null && errors.isNullOrEmpty()) {
+            return Outcome.success(successData)
+        }
+        val firstError = errors?.firstOrNull()
+        if (firstError != null) {
+            val extensions = firstError.extensions
+            val category = extensions?.get(EXT_CATEGORY)?.toString()
+            val reason = extensions?.get(EXT_REASON)?.toString()
+            val code = extensions?.get(EXT_CODE)?.toString()
+            val httpStatus = intFromExtensionOrNull(extensions?.get(EXT_HTTP_STATUS))
+            val dependency = extensions?.get(EXT_DEPENDENCY)?.toString()
+            val retryable = extensions?.get(EXT_RETRYABLE) as? Boolean ?: false
+            return Outcome.failure(
+                HeadwayRemoteGraphqlFailure.GraphQl(
+                    message = firstError.message,
+                    category = category,
+                    reason = reason,
+                    code = code,
+                    httpStatus = httpStatus,
+                    dependency = dependency,
+                    retryable = retryable,
+                ),
+            )
+        }
+        return if (successData != null) {
+            Outcome.success(successData)
+        } else {
+            Outcome.failure(HeadwayRemoteGraphqlFailure.UnexpectedResponse)
+        }
+    }
+
+    private fun mapFailure(throwable: Throwable): HeadwayRemoteGraphqlFailure = when (throwable) {
+        is ApolloNetworkException -> HeadwayRemoteGraphqlFailure.Network
+        is ApolloHttpException -> HeadwayRemoteGraphqlFailure.Network
+        else -> HeadwayRemoteGraphqlFailure.UnexpectedResponse
+    }
+
+    private fun intFromExtensionOrNull(value: Any?): Int? = when (value) {
+        null -> null
+        is Int -> value
+        is Long -> value.toInt()
+        is Double -> value.toInt()
+        is String -> value.toIntOrNull()
+        else -> value.toString().toIntOrNull()
+    }
+
+    private companion object {
+        const val EXT_CATEGORY: String = "category"
+        const val EXT_REASON: String = "reason"
+        const val EXT_CODE: String = "code"
+        const val EXT_HTTP_STATUS: String = "httpStatus"
+        const val EXT_DEPENDENCY: String = "dependency"
+        const val EXT_RETRYABLE: String = "retryable"
+    }
+}

--- a/client/core/design-system/build.gradle.kts
+++ b/client/core/design-system/build.gradle.kts
@@ -15,7 +15,7 @@ commonMainDependencies {
         implementation(bundles.compottie)
     }
     projects {
-        implementation(navigation.api)
+        implementation(navigation.navigationApi)
     }
 }
 

--- a/client/core/design-system/src/commonMain/kotlin/dev/kigya/headway/core/designSystem/component/preview/FreudFallbackPreview.kt
+++ b/client/core/design-system/src/commonMain/kotlin/dev/kigya/headway/core/designSystem/component/preview/FreudFallbackPreview.kt
@@ -65,8 +65,6 @@ private object FreudFallbackPreviewTheme : FreudTheme() {
         )
 }
 
-private const val SEPARATOR = " • "
-
 private data class FreudFallbackPreviewCase(
     val isDark: Boolean,
     val isWide: Boolean,
@@ -196,3 +194,5 @@ private fun FreudFallbackPreview(
         }
     }
 }
+
+private const val SEPARATOR = " • "

--- a/client/core/network/api/build.gradle.kts
+++ b/client/core/network/api/build.gradle.kts
@@ -1,0 +1,14 @@
+import extension.commonMainDependencies
+
+plugins {
+    alias(libs.plugins.convention.base.sharedLibrary)
+}
+
+commonMainDependencies {
+    projects {
+        implementation(core.outcome)
+    }
+    libs {
+        implementation(apollo.api)
+    }
+}

--- a/client/core/network/api/src/commonMain/kotlin/dev/kigya/headway/core/network/api/HeadwayAccessTokenStore.kt
+++ b/client/core/network/api/src/commonMain/kotlin/dev/kigya/headway/core/network/api/HeadwayAccessTokenStore.kt
@@ -1,0 +1,6 @@
+package dev.kigya.headway.core.network.api
+
+interface HeadwayAccessTokenStore {
+    fun current(): String?
+    fun update(value: String?)
+}

--- a/client/core/network/api/src/commonMain/kotlin/dev/kigya/headway/core/network/api/HeadwayGraphqlOperationExecutor.kt
+++ b/client/core/network/api/src/commonMain/kotlin/dev/kigya/headway/core/network/api/HeadwayGraphqlOperationExecutor.kt
@@ -1,0 +1,15 @@
+package dev.kigya.headway.core.network.api
+
+import com.apollographql.apollo.api.Mutation
+import com.apollographql.apollo.api.Query
+import dev.kigya.headway.core.outcome.Outcome
+
+interface HeadwayGraphqlOperationExecutor {
+    suspend fun <D : Query.Data> executeQuery(
+        query: Query<D>,
+    ): Outcome<HeadwayRemoteGraphqlFailure, D>
+
+    suspend fun <D : Mutation.Data> executeMutation(
+        mutation: Mutation<D>,
+    ): Outcome<HeadwayRemoteGraphqlFailure, D>
+}

--- a/client/core/network/api/src/commonMain/kotlin/dev/kigya/headway/core/network/api/HeadwayRemoteGraphqlFailure.kt
+++ b/client/core/network/api/src/commonMain/kotlin/dev/kigya/headway/core/network/api/HeadwayRemoteGraphqlFailure.kt
@@ -1,0 +1,18 @@
+package dev.kigya.headway.core.network.api
+
+sealed interface HeadwayRemoteGraphqlFailure {
+
+    data object Network : HeadwayRemoteGraphqlFailure
+
+    public data class GraphQl(
+        val message: String,
+        val category: String?,
+        val reason: String?,
+        val code: String?,
+        val httpStatus: Int?,
+        val dependency: String?,
+        val retryable: Boolean,
+    ) : HeadwayRemoteGraphqlFailure
+
+    data object UnexpectedResponse : HeadwayRemoteGraphqlFailure
+}

--- a/client/core/session/api/build.gradle.kts
+++ b/client/core/session/api/build.gradle.kts
@@ -1,0 +1,17 @@
+import extension.commonMainDependencies
+
+plugins {
+    alias(libs.plugins.convention.base.sharedLibrary)
+    alias(libs.plugins.convention.component.serialization)
+}
+
+commonMainDependencies {
+    projects {
+        implementation(core.networkApi)
+        implementation(core.outcome)
+    }
+    libs {
+        implementation(coroutines.core)
+        implementation(serializationJson)
+    }
+}

--- a/client/core/session/api/src/androidMain/kotlin/dev/kigya/headway/core/session/domain/usecase/SessionClock.android.kt
+++ b/client/core/session/api/src/androidMain/kotlin/dev/kigya/headway/core/session/domain/usecase/SessionClock.android.kt
@@ -1,0 +1,3 @@
+package dev.kigya.headway.core.session.domain.usecase
+
+internal actual fun readEpochMillis(): Long = System.currentTimeMillis()

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/HeadwaySessionGatewayPlatform.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/HeadwaySessionGatewayPlatform.kt
@@ -1,0 +1,8 @@
+package dev.kigya.headway.core.session.domain
+
+enum class HeadwaySessionGatewayPlatform {
+    Android,
+    Ios,
+    Desktop,
+    Web,
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/SessionRuntimeIdentityContract.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/SessionRuntimeIdentityContract.kt
@@ -1,0 +1,6 @@
+package dev.kigya.headway.core.session.domain
+
+interface SessionRuntimeIdentityContract {
+    val deviceFingerprint: String
+    val sessionGatewayPlatform: HeadwaySessionGatewayPlatform
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/contract/GoogleIdTokenAcquisitionContract.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/contract/GoogleIdTokenAcquisitionContract.kt
@@ -1,0 +1,8 @@
+package dev.kigya.headway.core.session.domain.contract
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+
+fun interface GoogleIdTokenAcquisitionContract {
+    suspend fun obtainIdToken(): Outcome<SessionDomainError, String>
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/error/SessionDomainError.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/error/SessionDomainError.kt
@@ -1,0 +1,16 @@
+package dev.kigya.headway.core.session.domain.error
+
+sealed interface SessionDomainError {
+    data object NetworkUnavailable : SessionDomainError
+    data object Unexpected : SessionDomainError
+    data object RegisteredSessionInvalid : SessionDomainError
+    data object GuestSessionInvalid : SessionDomainError
+    data object UserNotInvited : SessionDomainError
+    data object AuthorizationDenied : SessionDomainError
+    data object ValidationFailed : SessionDomainError
+    data object Conflict : SessionDomainError
+    data object DependencyUnavailable : SessionDomainError
+    data object LocalPersistenceFailed : SessionDomainError
+    data object GoogleSignInCancelled : SessionDomainError
+    data object GoogleSignInUnavailable : SessionDomainError
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/repository/AuthRepositoryContract.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/repository/AuthRepositoryContract.kt
@@ -1,0 +1,14 @@
+package dev.kigya.headway.core.session.domain.repository
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import dev.kigya.headway.core.session.model.LocalSessionRecord
+
+interface AuthRepositoryContract {
+    suspend fun loginWithGoogle(
+        idToken: String,
+    ): Outcome<SessionDomainError, LocalSessionRecord.Registered>
+    suspend fun loginAsGuest(): Outcome<SessionDomainError, LocalSessionRecord.Guest>
+    suspend fun refreshRegisteredAccess(refreshToken: String): Outcome<SessionDomainError, String>
+    suspend fun revokeGuestSession(): Outcome<SessionDomainError, Unit>
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/repository/LocalSessionPersistenceContract.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/repository/LocalSessionPersistenceContract.kt
@@ -1,0 +1,11 @@
+package dev.kigya.headway.core.session.domain.repository
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import dev.kigya.headway.core.session.model.LocalSessionRecord
+
+interface LocalSessionPersistenceContract {
+    suspend fun loadRecord(): Outcome<SessionDomainError, LocalSessionRecord?>
+    suspend fun saveRecord(record: LocalSessionRecord): Outcome<SessionDomainError, Unit>
+    suspend fun clearRecord(): Outcome<SessionDomainError, Unit>
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/repository/ProtectedRepositoryContract.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/repository/ProtectedRepositoryContract.kt
@@ -1,0 +1,11 @@
+package dev.kigya.headway.core.session.domain.repository
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import dev.kigya.headway.core.session.model.GuestLearningOverview
+import dev.kigya.headway.core.session.model.HomeScreenSummary
+
+interface ProtectedRepositoryContract {
+    suspend fun loadHomeSummary(): Outcome<SessionDomainError, HomeScreenSummary>
+    suspend fun loadGuestLearningOverview(): Outcome<SessionDomainError, GuestLearningOverview>
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/LoadGuestLearningOverviewUseCase.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/LoadGuestLearningOverviewUseCase.kt
@@ -1,0 +1,14 @@
+package dev.kigya.headway.core.session.domain.usecase
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import dev.kigya.headway.core.session.domain.repository.ProtectedRepositoryContract
+import dev.kigya.headway.core.session.model.GuestLearningOverview
+
+class LoadGuestLearningOverviewUseCase(
+    private val protectedRepository: ProtectedRepositoryContract,
+) {
+
+    suspend operator fun invoke(): Outcome<SessionDomainError, GuestLearningOverview> =
+        protectedRepository.loadGuestLearningOverview()
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/LoadHomeScreenSummaryUseCase.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/LoadHomeScreenSummaryUseCase.kt
@@ -1,0 +1,14 @@
+package dev.kigya.headway.core.session.domain.usecase
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import dev.kigya.headway.core.session.domain.repository.ProtectedRepositoryContract
+import dev.kigya.headway.core.session.model.HomeScreenSummary
+
+class LoadHomeScreenSummaryUseCase(
+    private val protectedRepository: ProtectedRepositoryContract,
+) {
+
+    suspend operator fun invoke(): Outcome<SessionDomainError, HomeScreenSummary> =
+        protectedRepository.loadHomeSummary()
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/LoginAsGuestUseCase.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/LoginAsGuestUseCase.kt
@@ -1,0 +1,27 @@
+package dev.kigya.headway.core.session.domain.usecase
+
+import dev.kigya.headway.core.network.api.HeadwayAccessTokenStore
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import dev.kigya.headway.core.session.domain.repository.AuthRepositoryContract
+import dev.kigya.headway.core.session.domain.repository.LocalSessionPersistenceContract
+
+class LoginAsGuestUseCase(
+    private val authRepository: AuthRepositoryContract,
+    private val persistence: LocalSessionPersistenceContract,
+    private val accessTokenStore: HeadwayAccessTokenStore,
+) {
+
+    suspend operator fun invoke(): Outcome<SessionDomainError, Unit> =
+        when (val guest = authRepository.loginAsGuest()) {
+            is Outcome.Success -> {
+                accessTokenStore.update(guest.value.accessToken)
+                when (val saved = persistence.saveRecord(guest.value)) {
+                    is Outcome.Success -> Outcome.success(Unit)
+                    is Outcome.Failure -> saved
+                }
+            }
+
+            is Outcome.Failure -> guest
+        }
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/LoginWithGoogleUseCase.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/LoginWithGoogleUseCase.kt
@@ -1,0 +1,27 @@
+package dev.kigya.headway.core.session.domain.usecase
+
+import dev.kigya.headway.core.network.api.HeadwayAccessTokenStore
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import dev.kigya.headway.core.session.domain.repository.AuthRepositoryContract
+import dev.kigya.headway.core.session.domain.repository.LocalSessionPersistenceContract
+
+class LoginWithGoogleUseCase(
+    private val authRepository: AuthRepositoryContract,
+    private val persistence: LocalSessionPersistenceContract,
+    private val accessTokenStore: HeadwayAccessTokenStore,
+) {
+
+    suspend operator fun invoke(idToken: String): Outcome<SessionDomainError, Unit> =
+        when (val registered = authRepository.loginWithGoogle(idToken)) {
+            is Outcome.Success -> {
+                accessTokenStore.update(registered.value.accessToken)
+                when (val saved = persistence.saveRecord(registered.value)) {
+                    is Outcome.Success -> Outcome.success(Unit)
+                    is Outcome.Failure -> saved
+                }
+            }
+
+            is Outcome.Failure -> registered
+        }
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/LogoutGuestUseCase.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/LogoutGuestUseCase.kt
@@ -1,0 +1,20 @@
+package dev.kigya.headway.core.session.domain.usecase
+
+import dev.kigya.headway.core.network.api.HeadwayAccessTokenStore
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import dev.kigya.headway.core.session.domain.repository.AuthRepositoryContract
+import dev.kigya.headway.core.session.domain.repository.LocalSessionPersistenceContract
+
+class LogoutGuestUseCase(
+    private val authRepository: AuthRepositoryContract,
+    private val persistence: LocalSessionPersistenceContract,
+    private val accessTokenStore: HeadwayAccessTokenStore,
+) {
+
+    suspend operator fun invoke(): Outcome<SessionDomainError, Unit> {
+        authRepository.revokeGuestSession()
+        accessTokenStore.update(null)
+        return persistence.clearRecord()
+    }
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/LogoutRegisteredUseCase.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/LogoutRegisteredUseCase.kt
@@ -1,0 +1,17 @@
+package dev.kigya.headway.core.session.domain.usecase
+
+import dev.kigya.headway.core.network.api.HeadwayAccessTokenStore
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import dev.kigya.headway.core.session.domain.repository.LocalSessionPersistenceContract
+
+class LogoutRegisteredUseCase(
+    private val persistence: LocalSessionPersistenceContract,
+    private val accessTokenStore: HeadwayAccessTokenStore,
+) {
+
+    suspend operator fun invoke(): Outcome<SessionDomainError, Unit> {
+        accessTokenStore.update(null)
+        return persistence.clearRecord()
+    }
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/ObtainGoogleIdTokenUseCase.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/ObtainGoogleIdTokenUseCase.kt
@@ -1,0 +1,11 @@
+package dev.kigya.headway.core.session.domain.usecase
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.contract.GoogleIdTokenAcquisitionContract
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+
+class ObtainGoogleIdTokenUseCase(
+    private val acquisition: GoogleIdTokenAcquisitionContract,
+) {
+    suspend operator fun invoke(): Outcome<SessionDomainError, String> = acquisition.obtainIdToken()
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/ResolveLaunchDestinationUseCase.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/ResolveLaunchDestinationUseCase.kt
@@ -1,0 +1,113 @@
+package dev.kigya.headway.core.session.domain.usecase
+
+import dev.kigya.headway.core.network.api.HeadwayAccessTokenStore
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.outcome.getOrElse
+import dev.kigya.headway.core.outcome.getOrNull
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import dev.kigya.headway.core.session.domain.repository.AuthRepositoryContract
+import dev.kigya.headway.core.session.domain.repository.LocalSessionPersistenceContract
+import dev.kigya.headway.core.session.domain.repository.ProtectedRepositoryContract
+import dev.kigya.headway.core.session.model.LaunchDestination
+import dev.kigya.headway.core.session.model.LocalSessionRecord
+
+class ResolveLaunchDestinationUseCase(
+    private val persistence: LocalSessionPersistenceContract,
+    private val protectedRepository: ProtectedRepositoryContract,
+    private val authRepository: AuthRepositoryContract,
+    private val accessTokenStore: HeadwayAccessTokenStore,
+    private val clock: SessionClock,
+) {
+
+    suspend operator fun invoke(): Outcome<SessionDomainError, LaunchDestination> {
+        val record = persistence.loadRecord().getOrElse { return Outcome.success(LaunchDestination.Auth) }
+            ?: return Outcome.success(LaunchDestination.Auth)
+
+        return when (record) {
+            is LocalSessionRecord.Guest -> resolveGuest(record)
+            is LocalSessionRecord.Registered -> resolveRegistered(record)
+        }
+    }
+
+    private suspend fun resolveGuest(
+        record: LocalSessionRecord.Guest,
+    ): Outcome<SessionDomainError, LaunchDestination> {
+        if (clock.nowEpochMillis() >= record.expiresAtEpochMs) {
+            persistence.clearRecord()
+            accessTokenStore.update(null)
+            return Outcome.success(LaunchDestination.Auth)
+        }
+        accessTokenStore.update(record.accessToken)
+        return when (val overview = protectedRepository.loadGuestLearningOverview()) {
+            is Outcome.Success -> Outcome.success(LaunchDestination.LearnQuestions)
+            is Outcome.Failure -> guestFailure(overview.error)
+        }
+    }
+
+    private suspend fun guestFailure(
+        error: SessionDomainError,
+    ): Outcome<SessionDomainError, LaunchDestination> {
+        if (error == SessionDomainError.NetworkUnavailable ||
+            error == SessionDomainError.DependencyUnavailable
+        ) {
+            return Outcome.success(LaunchDestination.Auth)
+        }
+        persistence.clearRecord()
+        accessTokenStore.update(null)
+        return Outcome.success(LaunchDestination.Auth)
+    }
+
+    private suspend fun resolveRegistered(
+        record: LocalSessionRecord.Registered,
+    ): Outcome<SessionDomainError, LaunchDestination> {
+        accessTokenStore.update(record.accessToken)
+        return when (val home = protectedRepository.loadHomeSummary()) {
+            is Outcome.Success -> Outcome.success(LaunchDestination.Home)
+            is Outcome.Failure -> registeredHomeFailure(record, home.error)
+        }
+    }
+
+    private suspend fun registeredHomeFailure(
+        record: LocalSessionRecord.Registered,
+        error: SessionDomainError,
+    ): Outcome<SessionDomainError, LaunchDestination> {
+        when (error) {
+            SessionDomainError.RegisteredSessionInvalid -> {
+                val newAccess = authRepository.refreshRegisteredAccess(record.refreshToken).getOrNull()
+                if (newAccess == null) {
+                    persistence.clearRecord()
+                    accessTokenStore.update(null)
+                    return Outcome.success(LaunchDestination.Auth)
+                }
+                val updated = record.copy(accessToken = newAccess)
+                persistence.saveRecord(updated)
+                accessTokenStore.update(newAccess)
+                return when (protectedRepository.loadHomeSummary()) {
+                    is Outcome.Success -> Outcome.success(LaunchDestination.Home)
+                    is Outcome.Failure -> {
+                        persistence.clearRecord()
+                        accessTokenStore.update(null)
+                        Outcome.success(LaunchDestination.Auth)
+                    }
+                }
+            }
+            SessionDomainError.NetworkUnavailable,
+            SessionDomainError.DependencyUnavailable,
+            -> return Outcome.success(LaunchDestination.Auth)
+            SessionDomainError.AuthorizationDenied,
+            SessionDomainError.UserNotInvited,
+            SessionDomainError.GuestSessionInvalid,
+            SessionDomainError.Unexpected,
+            SessionDomainError.ValidationFailed,
+            SessionDomainError.Conflict,
+            SessionDomainError.LocalPersistenceFailed,
+            SessionDomainError.GoogleSignInCancelled,
+            SessionDomainError.GoogleSignInUnavailable,
+            -> {
+                persistence.clearRecord()
+                accessTokenStore.update(null)
+                return Outcome.success(LaunchDestination.Auth)
+            }
+        }
+    }
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/SessionClock.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/usecase/SessionClock.kt
@@ -1,0 +1,9 @@
+package dev.kigya.headway.core.session.domain.usecase
+
+fun interface SessionClock {
+    fun nowEpochMillis(): Long
+}
+
+internal expect fun readEpochMillis(): Long
+
+fun systemSessionClock(): SessionClock = SessionClock { readEpochMillis() }

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/model/GuestLearningOverview.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/model/GuestLearningOverview.kt
@@ -1,0 +1,6 @@
+package dev.kigya.headway.core.session.model
+
+data class GuestLearningOverview(
+    val headline: String,
+    val detailLine: String,
+)

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/model/HomeScreenSummary.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/model/HomeScreenSummary.kt
@@ -1,0 +1,5 @@
+package dev.kigya.headway.core.session.model
+
+data class HomeScreenSummary(
+    val greeting: String,
+)

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/model/LaunchDestination.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/model/LaunchDestination.kt
@@ -1,0 +1,7 @@
+package dev.kigya.headway.core.session.model
+
+sealed interface LaunchDestination {
+    data object Auth : LaunchDestination
+    data object Home : LaunchDestination
+    data object LearnQuestions : LaunchDestination
+}

--- a/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/model/LocalSessionRecord.kt
+++ b/client/core/session/api/src/commonMain/kotlin/dev/kigya/headway/core/session/model/LocalSessionRecord.kt
@@ -1,0 +1,25 @@
+package dev.kigya.headway.core.session.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface LocalSessionRecord {
+
+    @Serializable
+    @SerialName("registered")
+    data class Registered(
+        @SerialName("accessToken") val accessToken: String,
+        @SerialName("refreshToken") val refreshToken: String,
+        @SerialName("userId") val userId: String,
+        @SerialName("userEmail") val userEmail: String,
+        @SerialName("userName") val userName: String,
+    ) : LocalSessionRecord
+
+    @Serializable
+    @SerialName("guest")
+    data class Guest(
+        @SerialName("accessToken") val accessToken: String,
+        @SerialName("expiresAtEpochMs") val expiresAtEpochMs: Long,
+    ) : LocalSessionRecord
+}

--- a/client/core/session/api/src/desktopMain/kotlin/dev/kigya/headway/core/session/domain/usecase/SessionClock.desktop.kt
+++ b/client/core/session/api/src/desktopMain/kotlin/dev/kigya/headway/core/session/domain/usecase/SessionClock.desktop.kt
@@ -1,0 +1,3 @@
+package dev.kigya.headway.core.session.domain.usecase
+
+internal actual fun readEpochMillis(): Long = System.currentTimeMillis()

--- a/client/core/session/api/src/iosMain/kotlin/dev/kigya/headway/core/session/domain/usecase/SessionClock.ios.kt
+++ b/client/core/session/api/src/iosMain/kotlin/dev/kigya/headway/core/session/domain/usecase/SessionClock.ios.kt
@@ -1,0 +1,13 @@
+package dev.kigya.headway.core.session.domain.usecase
+
+import platform.Foundation.NSDate
+
+internal actual fun readEpochMillis(): Long {
+    val secondsSinceUnixEpoch =
+        NSDate().timeIntervalSinceReferenceDate + SECONDS_FROM_UNIX_EPOCH_TO_NS_DATE_REFERENCE
+    return (secondsSinceUnixEpoch * MILLIS_PER_SECOND).toLong()
+}
+
+private const val MILLIS_PER_SECOND: Double = 1_000.0
+
+private const val SECONDS_FROM_UNIX_EPOCH_TO_NS_DATE_REFERENCE: Double = 978_307_200.0

--- a/client/core/session/api/src/wasmJsMain/kotlin/dev/kigya/headway/core/session/domain/usecase/SessionClock.wasmJs.kt
+++ b/client/core/session/api/src/wasmJsMain/kotlin/dev/kigya/headway/core/session/domain/usecase/SessionClock.wasmJs.kt
@@ -1,0 +1,7 @@
+package dev.kigya.headway.core.session.domain.usecase
+
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+internal actual fun readEpochMillis(): Long = Clock.System.now().toEpochMilliseconds()

--- a/client/core/session/internal/build.gradle.kts
+++ b/client/core/session/internal/build.gradle.kts
@@ -1,0 +1,43 @@
+import extension.androidMainDependencies
+import extension.commonMainDependencies
+import extension.desktopMainDependencies
+import extension.iosMainDependencies
+import extension.wasmMainDependencies
+
+plugins {
+    alias(libs.plugins.convention.base.sharedLibrary)
+    alias(libs.plugins.convention.component.koin)
+    alias(libs.plugins.convention.component.serialization)
+}
+
+commonMainDependencies {
+    projects {
+        api(core.sessionApi)
+        implementation(core.apollo)
+        implementation(core.networkApi)
+        implementation(core.outcome)
+        implementation(core.storageApi)
+    }
+    libs {
+        implementation(apollo.runtime)
+        implementation(coroutines.core)
+        implementation(koin.core)
+        implementation(serializationJson)
+    }
+}
+
+androidMainDependencies {
+    libs {
+        implementation(activity.ktx)
+        implementation(play.services.auth)
+    }
+}
+
+iosMainDependencies {
+}
+
+desktopMainDependencies {
+}
+
+wasmMainDependencies {
+}

--- a/client/core/session/internal/src/androidMain/kotlin/dev/kigya/headway/core/session/android/google/HeadwayAndroidGoogleIdTokenAcquisition.kt
+++ b/client/core/session/internal/src/androidMain/kotlin/dev/kigya/headway/core/session/android/google/HeadwayAndroidGoogleIdTokenAcquisition.kt
@@ -1,0 +1,24 @@
+package dev.kigya.headway.core.session.android.google
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.contract.GoogleIdTokenAcquisitionContract
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+internal class HeadwayAndroidGoogleIdTokenAcquisition(
+    private val bridge: HeadwayAndroidGoogleSignInBridge,
+) : GoogleIdTokenAcquisitionContract {
+
+    override suspend fun obtainIdToken(): Outcome<SessionDomainError, String> =
+        suspendCancellableCoroutine { continuation ->
+            bridge.beginSignInForIdToken { outcome ->
+                if (continuation.isActive) {
+                    continuation.resume(outcome)
+                }
+            }
+            continuation.invokeOnCancellation {
+                bridge.cancelPendingSignIn()
+            }
+        }
+}

--- a/client/core/session/internal/src/androidMain/kotlin/dev/kigya/headway/core/session/android/google/HeadwayAndroidGoogleSignInBridge.kt
+++ b/client/core/session/internal/src/androidMain/kotlin/dev/kigya/headway/core/session/android/google/HeadwayAndroidGoogleSignInBridge.kt
@@ -1,0 +1,33 @@
+package dev.kigya.headway.core.session.android.google
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+
+class HeadwayAndroidGoogleSignInBridge {
+
+    @Volatile
+    private var host: HeadwayAndroidGoogleSignInFlow? = null
+
+    fun attach(host: HeadwayAndroidGoogleSignInFlow) {
+        this.host = host
+    }
+
+    fun detach(host: HeadwayAndroidGoogleSignInFlow) {
+        if (this.host === host) {
+            this.host = null
+        }
+    }
+
+    fun cancelPendingSignIn() {
+        host?.cancelPendingGoogleSignIn()
+    }
+
+    fun beginSignInForIdToken(onResult: (Outcome<SessionDomainError, String>) -> Unit) {
+        val current = host
+        if (current == null) {
+            onResult(Outcome.failure(SessionDomainError.GoogleSignInUnavailable))
+        } else {
+            current.beginGoogleSignInForIdToken(onResult)
+        }
+    }
+}

--- a/client/core/session/internal/src/androidMain/kotlin/dev/kigya/headway/core/session/android/google/HeadwayAndroidGoogleSignInFlow.kt
+++ b/client/core/session/internal/src/androidMain/kotlin/dev/kigya/headway/core/session/android/google/HeadwayAndroidGoogleSignInFlow.kt
@@ -1,0 +1,94 @@
+package dev.kigya.headway.core.session.android.google
+
+import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.gms.auth.api.signin.GoogleSignInStatusCodes
+import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.common.api.CommonStatusCodes
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+
+class HeadwayAndroidGoogleSignInFlow(
+    private val activity: ComponentActivity,
+) {
+
+    private var pendingGoogleResult: ((Outcome<SessionDomainError, String>) -> Unit)? = null
+
+    private val googleSignInLauncher = activity.registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { activityResult ->
+        val callback = pendingGoogleResult
+        pendingGoogleResult = null
+        if (callback == null) {
+            return@registerForActivityResult
+        }
+        val data: Intent? = activityResult.data
+        val task = GoogleSignIn.getSignedInAccountFromIntent(data)
+        try {
+            val account = task.getResult(ApiException::class.java)
+            val idToken = account.idToken
+            if (idToken.isNullOrBlank()) {
+                callback(Outcome.failure(SessionDomainError.GoogleSignInUnavailable))
+            } else {
+                callback(Outcome.success(idToken))
+            }
+        } catch (exception: ApiException) {
+            when (exception.statusCode) {
+                GoogleSignInStatusCodes.SIGN_IN_CANCELLED,
+                CommonStatusCodes.CANCELED,
+                -> callback(Outcome.failure(SessionDomainError.GoogleSignInCancelled))
+
+                else -> callback(Outcome.failure(SessionDomainError.GoogleSignInUnavailable))
+            }
+        }
+    }
+
+    fun beginGoogleSignInForIdToken(
+        onResult: (Outcome<SessionDomainError, String>) -> Unit,
+    ) {
+        activity.runOnUiThread {
+            val webClientId = resolveGoogleWebClientId(activity)
+            if (webClientId.isEmpty()) {
+                onResult(Outcome.failure(SessionDomainError.GoogleSignInUnavailable))
+                return@runOnUiThread
+            }
+            pendingGoogleResult = onResult
+            val options = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                .requestIdToken(webClientId)
+                .requestEmail()
+                .build()
+            val client = GoogleSignIn.getClient(activity, options)
+            client.signOut().addOnCompleteListener {
+                activity.runOnUiThread {
+                    googleSignInLauncher.launch(
+                        GoogleSignIn.getClient(activity, options).signInIntent,
+                    )
+                }
+            }
+        }
+    }
+
+    fun cancelPendingGoogleSignIn() {
+        pendingGoogleResult = null
+    }
+
+    fun onDestroy() {
+        val pending = pendingGoogleResult
+        pendingGoogleResult = null
+        pending?.let { it(Outcome.failure(SessionDomainError.GoogleSignInUnavailable)) }
+    }
+}
+
+private fun resolveGoogleWebClientId(activity: ComponentActivity): String {
+    val applicationInfo = activity.packageManager.getApplicationInfo(
+        activity.packageName,
+        PackageManager.GET_META_DATA,
+    )
+    return applicationInfo.metaData?.getString(HEADWAY_GOOGLE_WEB_CLIENT_ID_META_KEY)?.trim().orEmpty()
+}
+
+private const val HEADWAY_GOOGLE_WEB_CLIENT_ID_META_KEY: String = "headway.google.webClientId"

--- a/client/core/session/internal/src/androidMain/kotlin/dev/kigya/headway/core/session/android/google/HeadwayAndroidGoogleSignInFlow.kt
+++ b/client/core/session/internal/src/androidMain/kotlin/dev/kigya/headway/core/session/android/google/HeadwayAndroidGoogleSignInFlow.kt
@@ -47,9 +47,7 @@ class HeadwayAndroidGoogleSignInFlow(
         }
     }
 
-    fun beginGoogleSignInForIdToken(
-        onResult: (Outcome<SessionDomainError, String>) -> Unit,
-    ) {
+    fun beginGoogleSignInForIdToken(onResult: (Outcome<SessionDomainError, String>) -> Unit) {
         activity.runOnUiThread {
             val webClientId = resolveGoogleWebClientId(activity)
             if (webClientId.isEmpty()) {

--- a/client/core/session/internal/src/androidMain/kotlin/dev/kigya/headway/core/session/android/google/HeadwayAndroidSessionGoogleKoinModule.kt
+++ b/client/core/session/internal/src/androidMain/kotlin/dev/kigya/headway/core/session/android/google/HeadwayAndroidSessionGoogleKoinModule.kt
@@ -1,0 +1,12 @@
+package dev.kigya.headway.core.session.android.google
+
+import dev.kigya.headway.core.session.domain.contract.GoogleIdTokenAcquisitionContract
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+fun headwayAndroidSessionGoogleModule(): Module = module {
+    single { HeadwayAndroidGoogleSignInBridge() }
+    single<GoogleIdTokenAcquisitionContract> {
+        HeadwayAndroidGoogleIdTokenAcquisition(bridge = get())
+    }
+}

--- a/client/core/session/internal/src/commonMain/kotlin/dev/kigya/headway/core/session/data/AuthRepository.kt
+++ b/client/core/session/internal/src/commonMain/kotlin/dev/kigya/headway/core/session/data/AuthRepository.kt
@@ -74,8 +74,8 @@ internal class AuthRepository(
 
 private fun HeadwaySessionGatewayPlatform.toGatewaySessionPlatform(): GatewaySessionPlatform =
     when (this) {
-    HeadwaySessionGatewayPlatform.Android -> GatewaySessionPlatform.ANDROID
-    HeadwaySessionGatewayPlatform.Ios -> GatewaySessionPlatform.IOS
-    HeadwaySessionGatewayPlatform.Desktop -> GatewaySessionPlatform.DESKTOP
-    HeadwaySessionGatewayPlatform.Web -> GatewaySessionPlatform.WEB
-}
+        HeadwaySessionGatewayPlatform.Android -> GatewaySessionPlatform.ANDROID
+        HeadwaySessionGatewayPlatform.Ios -> GatewaySessionPlatform.IOS
+        HeadwaySessionGatewayPlatform.Desktop -> GatewaySessionPlatform.DESKTOP
+        HeadwaySessionGatewayPlatform.Web -> GatewaySessionPlatform.WEB
+    }

--- a/client/core/session/internal/src/commonMain/kotlin/dev/kigya/headway/core/session/data/AuthRepository.kt
+++ b/client/core/session/internal/src/commonMain/kotlin/dev/kigya/headway/core/session/data/AuthRepository.kt
@@ -1,0 +1,80 @@
+package dev.kigya.headway.core.session.data
+
+import com.apollographql.apollo.api.Optional
+import dev.kigya.headway.core.apollo.generated.LoginAsGuestMutation
+import dev.kigya.headway.core.apollo.generated.LoginWithGoogleMutation
+import dev.kigya.headway.core.apollo.generated.LogoutGuestMutation
+import dev.kigya.headway.core.apollo.generated.RefreshTokenMutation
+import dev.kigya.headway.core.apollo.generated.type.GatewaySessionPlatform
+import dev.kigya.headway.core.network.api.HeadwayGraphqlOperationExecutor
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.outcome.mapFailure
+import dev.kigya.headway.core.outcome.mapSuccess
+import dev.kigya.headway.core.session.domain.HeadwaySessionGatewayPlatform
+import dev.kigya.headway.core.session.domain.SessionRuntimeIdentityContract
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import dev.kigya.headway.core.session.domain.error.mapHeadwayGraphqlFailureToSessionError
+import dev.kigya.headway.core.session.domain.repository.AuthRepositoryContract
+import dev.kigya.headway.core.session.model.LocalSessionRecord
+
+internal class AuthRepository(
+    private val executor: HeadwayGraphqlOperationExecutor,
+    private val runtimeIdentity: SessionRuntimeIdentityContract,
+) : AuthRepositoryContract {
+
+    override suspend fun loginWithGoogle(
+        idToken: String,
+    ): Outcome<SessionDomainError, LocalSessionRecord.Registered> {
+        val mutation = LoginWithGoogleMutation(
+            idToken = idToken,
+            fingerprint = runtimeIdentity.deviceFingerprint,
+            platform = runtimeIdentity.sessionGatewayPlatform.toGatewaySessionPlatform(),
+        )
+        return executor.executeMutation(mutation)
+            .mapFailure(::mapHeadwayGraphqlFailureToSessionError)
+            .mapSuccess { data ->
+                val payload = data.loginWithGoogle
+                LocalSessionRecord.Registered(
+                    accessToken = payload.accessToken,
+                    refreshToken = payload.refreshToken,
+                    userId = payload.user.id.toString(),
+                    userEmail = payload.user.email,
+                    userName = payload.user.name,
+                )
+            }
+    }
+
+    override suspend fun loginAsGuest(): Outcome<SessionDomainError, LocalSessionRecord.Guest> {
+        val mutation = LoginAsGuestMutation(stub = Optional.Absent)
+        return executor.executeMutation(mutation).mapFailure(::mapHeadwayGraphqlFailureToSessionError)
+            .mapSuccess { data ->
+                val payload = data.loginAsGuest
+                LocalSessionRecord.Guest(
+                    accessToken = payload.accessToken,
+                    expiresAtEpochMs = payload.expiresAtEpochMs,
+                )
+            }
+    }
+
+    override suspend fun refreshRegisteredAccess(
+        refreshToken: String,
+    ): Outcome<SessionDomainError, String> {
+        val mutation = RefreshTokenMutation(
+            refreshToken = refreshToken,
+            fingerprint = runtimeIdentity.deviceFingerprint,
+        )
+        return executor.executeMutation(mutation).mapFailure(::mapHeadwayGraphqlFailureToSessionError)
+            .mapSuccess { it.refreshToken.accessToken }
+    }
+
+    override suspend fun revokeGuestSession(): Outcome<SessionDomainError, Unit> =
+        executor.executeMutation(LogoutGuestMutation()).mapFailure(::mapHeadwayGraphqlFailureToSessionError)
+            .mapSuccess { }
+}
+
+private fun HeadwaySessionGatewayPlatform.toGatewaySessionPlatform(): GatewaySessionPlatform = when (this) {
+    HeadwaySessionGatewayPlatform.Android -> GatewaySessionPlatform.ANDROID
+    HeadwaySessionGatewayPlatform.Ios -> GatewaySessionPlatform.IOS
+    HeadwaySessionGatewayPlatform.Desktop -> GatewaySessionPlatform.DESKTOP
+    HeadwaySessionGatewayPlatform.Web -> GatewaySessionPlatform.WEB
+}

--- a/client/core/session/internal/src/commonMain/kotlin/dev/kigya/headway/core/session/data/AuthRepository.kt
+++ b/client/core/session/internal/src/commonMain/kotlin/dev/kigya/headway/core/session/data/AuthRepository.kt
@@ -72,7 +72,8 @@ internal class AuthRepository(
             .mapSuccess { }
 }
 
-private fun HeadwaySessionGatewayPlatform.toGatewaySessionPlatform(): GatewaySessionPlatform = when (this) {
+private fun HeadwaySessionGatewayPlatform.toGatewaySessionPlatform(): GatewaySessionPlatform =
+    when (this) {
     HeadwaySessionGatewayPlatform.Android -> GatewaySessionPlatform.ANDROID
     HeadwaySessionGatewayPlatform.Ios -> GatewaySessionPlatform.IOS
     HeadwaySessionGatewayPlatform.Desktop -> GatewaySessionPlatform.DESKTOP

--- a/client/core/session/internal/src/commonMain/kotlin/dev/kigya/headway/core/session/data/DefaultLocalSessionPersistenceRepository.kt
+++ b/client/core/session/internal/src/commonMain/kotlin/dev/kigya/headway/core/session/data/DefaultLocalSessionPersistenceRepository.kt
@@ -1,0 +1,50 @@
+package dev.kigya.headway.core.session.data
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.outcome.outcomeSuspendCatching
+import dev.kigya.headway.core.secureStorage.SecureSessionStorageContract
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import dev.kigya.headway.core.session.domain.repository.LocalSessionPersistenceContract
+import dev.kigya.headway.core.session.model.LocalSessionRecord
+import kotlinx.serialization.json.Json
+
+internal class DefaultLocalSessionPersistenceRepository(
+    private val secureStorage: SecureSessionStorageContract,
+) : LocalSessionPersistenceContract {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    override suspend fun loadRecord(): Outcome<SessionDomainError, LocalSessionRecord?> =
+        when (val loaded = secureStorage.loadPayload()) {
+            is Outcome.Failure -> Outcome.failure(SessionDomainError.LocalPersistenceFailed)
+            is Outcome.Success -> outcomeSuspendCatching(
+                mapError = { SessionDomainError.LocalPersistenceFailed },
+            ) {
+                val raw = loaded.value ?: return@outcomeSuspendCatching null
+                json.decodeFromString<LocalSessionRecord>(raw)
+            }
+        }
+
+    override suspend fun saveRecord(record: LocalSessionRecord): Outcome<SessionDomainError, Unit> =
+        when (
+            val encoded = outcomeSuspendCatching(
+                mapError = { SessionDomainError.LocalPersistenceFailed },
+            ) {
+                json.encodeToString(LocalSessionRecord.serializer(), record)
+            }
+        ) {
+            is Outcome.Failure -> Outcome.failure(encoded.error)
+            is Outcome.Success -> when (secureStorage.savePayload(encoded.value)) {
+                is Outcome.Failure -> Outcome.failure(SessionDomainError.LocalPersistenceFailed)
+                is Outcome.Success -> Outcome.success(Unit)
+            }
+        }
+
+    override suspend fun clearRecord(): Outcome<SessionDomainError, Unit> =
+        when (secureStorage.clear()) {
+            is Outcome.Failure -> Outcome.failure(SessionDomainError.LocalPersistenceFailed)
+            is Outcome.Success -> Outcome.success(Unit)
+        }
+}

--- a/client/core/session/internal/src/commonMain/kotlin/dev/kigya/headway/core/session/data/DefaultProtectedRepository.kt
+++ b/client/core/session/internal/src/commonMain/kotlin/dev/kigya/headway/core/session/data/DefaultProtectedRepository.kt
@@ -1,0 +1,62 @@
+package dev.kigya.headway.core.session.data
+
+import com.apollographql.apollo.api.Optional
+import dev.kigya.headway.core.apollo.generated.HomeScreenQuery
+import dev.kigya.headway.core.apollo.generated.LearningQuestionsCatalogQuery
+import dev.kigya.headway.core.network.api.HeadwayGraphqlOperationExecutor
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.outcome.mapFailure
+import dev.kigya.headway.core.outcome.mapSuccess
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import dev.kigya.headway.core.session.domain.error.mapHeadwayGraphqlFailureToSessionError
+import dev.kigya.headway.core.session.domain.repository.LocalSessionPersistenceContract
+import dev.kigya.headway.core.session.domain.repository.ProtectedRepositoryContract
+import dev.kigya.headway.core.session.model.GuestLearningOverview
+import dev.kigya.headway.core.session.model.HomeScreenSummary
+import dev.kigya.headway.core.session.model.LocalSessionRecord
+
+internal class DefaultProtectedRepository(
+    private val persistence: LocalSessionPersistenceContract,
+    private val executor: HeadwayGraphqlOperationExecutor,
+) : ProtectedRepositoryContract {
+
+    override suspend fun loadHomeSummary(): Outcome<SessionDomainError, HomeScreenSummary> =
+        when (val loaded = persistence.loadRecord()) {
+            is Outcome.Failure -> Outcome.failure(loaded.error)
+            is Outcome.Success -> when (loaded.value) {
+                is LocalSessionRecord.Registered ->
+                    executor.executeQuery(HomeScreenQuery()).mapFailure(::mapHeadwayGraphqlFailureToSessionError)
+                        .mapSuccess { data ->
+                            HomeScreenSummary(greeting = data.homeScreen.greeting)
+                        }
+
+                null,
+                is LocalSessionRecord.Guest,
+                -> Outcome.failure(SessionDomainError.AuthorizationDenied)
+            }
+        }
+
+    override suspend fun loadGuestLearningOverview(): Outcome<SessionDomainError, GuestLearningOverview> =
+        when (val loaded = persistence.loadRecord()) {
+            is Outcome.Failure -> Outcome.failure(loaded.error)
+            is Outcome.Success -> when (loaded.value) {
+                is LocalSessionRecord.Guest ->
+                    LearningQuestionsCatalogQuery(subjectUserId = Optional.Absent).let { query ->
+                        executor.executeQuery(query).mapFailure(::mapHeadwayGraphqlFailureToSessionError)
+                            .mapSuccess { data ->
+                                val catalog = data.learningQuestionsCatalog
+                                val hardCount = catalog.hardSkills.size
+                                val softCount = catalog.softSkills.size
+                                GuestLearningOverview(
+                                    headline = "Learning catalog",
+                                    detailLine = "$hardCount hard skills · $softCount soft skills",
+                                )
+                            }
+                    }
+
+                null,
+                is LocalSessionRecord.Registered,
+                -> Outcome.failure(SessionDomainError.AuthorizationDenied)
+            }
+        }
+}

--- a/client/core/session/internal/src/commonMain/kotlin/dev/kigya/headway/core/session/di/SessionDomainModule.kt
+++ b/client/core/session/internal/src/commonMain/kotlin/dev/kigya/headway/core/session/di/SessionDomainModule.kt
@@ -1,0 +1,36 @@
+package dev.kigya.headway.core.session.di
+
+import dev.kigya.headway.core.session.data.AuthRepository
+import dev.kigya.headway.core.session.data.DefaultLocalSessionPersistenceRepository
+import dev.kigya.headway.core.session.data.DefaultProtectedRepository
+import dev.kigya.headway.core.session.domain.repository.AuthRepositoryContract
+import dev.kigya.headway.core.session.domain.repository.LocalSessionPersistenceContract
+import dev.kigya.headway.core.session.domain.repository.ProtectedRepositoryContract
+import dev.kigya.headway.core.session.domain.usecase.LoadGuestLearningOverviewUseCase
+import dev.kigya.headway.core.session.domain.usecase.LoadHomeScreenSummaryUseCase
+import dev.kigya.headway.core.session.domain.usecase.LoginAsGuestUseCase
+import dev.kigya.headway.core.session.domain.usecase.LoginWithGoogleUseCase
+import dev.kigya.headway.core.session.domain.usecase.LogoutGuestUseCase
+import dev.kigya.headway.core.session.domain.usecase.LogoutRegisteredUseCase
+import dev.kigya.headway.core.session.domain.usecase.ObtainGoogleIdTokenUseCase
+import dev.kigya.headway.core.session.domain.usecase.ResolveLaunchDestinationUseCase
+import dev.kigya.headway.core.session.domain.usecase.SessionClock
+import dev.kigya.headway.core.session.domain.usecase.systemSessionClock
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+fun sessionDomainModule() = module {
+    single<SessionClock> { systemSessionClock() }
+    singleOf(::DefaultLocalSessionPersistenceRepository) bind LocalSessionPersistenceContract::class
+    singleOf(::AuthRepository) bind AuthRepositoryContract::class
+    singleOf(::DefaultProtectedRepository) bind ProtectedRepositoryContract::class
+    singleOf(::ResolveLaunchDestinationUseCase)
+    singleOf(::ObtainGoogleIdTokenUseCase)
+    singleOf(::LoginWithGoogleUseCase)
+    singleOf(::LoginAsGuestUseCase)
+    singleOf(::LogoutRegisteredUseCase)
+    singleOf(::LogoutGuestUseCase)
+    singleOf(::LoadHomeScreenSummaryUseCase)
+    singleOf(::LoadGuestLearningOverviewUseCase)
+}

--- a/client/core/session/internal/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/error/SessionGraphqlFailureMapper.kt
+++ b/client/core/session/internal/src/commonMain/kotlin/dev/kigya/headway/core/session/domain/error/SessionGraphqlFailureMapper.kt
@@ -1,0 +1,63 @@
+package dev.kigya.headway.core.session.domain.error
+
+import dev.kigya.headway.core.network.api.HeadwayRemoteGraphqlFailure
+
+internal fun mapHeadwayGraphqlFailureToSessionError(
+    failure: HeadwayRemoteGraphqlFailure,
+): SessionDomainError = when (failure) {
+    HeadwayRemoteGraphqlFailure.Network -> SessionDomainError.NetworkUnavailable
+    HeadwayRemoteGraphqlFailure.UnexpectedResponse -> SessionDomainError.Unexpected
+    is HeadwayRemoteGraphqlFailure.GraphQl -> mapGraphQlFailure(failure)
+}
+
+private fun mapGraphQlFailure(failure: HeadwayRemoteGraphqlFailure.GraphQl): SessionDomainError =
+    sessionErrorForGraphQlWireKey(failure.reason)
+        ?: sessionErrorForGraphQlWireKey(failure.code)
+        ?: sessionErrorForGraphQlCategory(failure.category)
+
+private fun sessionErrorForGraphQlWireKey(raw: String?): SessionDomainError? =
+    when (raw?.uppercase()) {
+        "ACCESS_TOKEN_EXPIRED",
+        "INVALID_ACCESS_TOKEN",
+        "INVALID_REFRESH_TOKEN",
+        "EMPTY_REFRESH_TOKEN",
+        "MISSING_AUTH_HEADER",
+        "MALFORMED_BEARER_HEADER",
+        "EMPTY_ID_TOKEN",
+        "ACCOUNT_INACTIVE",
+        "UNAUTHENTICATED",
+        -> SessionDomainError.RegisteredSessionInvalid
+        "GUEST_TOKEN_EXPIRED",
+        "INVALID_GUEST_TOKEN",
+        -> SessionDomainError.GuestSessionInvalid
+        "USER_NOT_INVITED",
+        -> SessionDomainError.UserNotInvited
+        "INSUFFICIENT_ROLE",
+        "GUEST_NOT_ALLOWED",
+        "GOOGLE_EMAIL_NOT_VERIFIED",
+        "FORBIDDEN",
+        -> SessionDomainError.AuthorizationDenied
+        "DEPENDENCY_FAILURE",
+        "UPSTREAM_PROTOCOL",
+        "BAD_GATEWAY",
+        "SERVICE_UNAVAILABLE",
+        -> SessionDomainError.DependencyUnavailable
+        "IDENTITY_CONFLICT",
+        -> SessionDomainError.Conflict
+        "BAD_REQUEST",
+        "EMPTY_FINGERPRINT",
+        -> SessionDomainError.ValidationFailed
+        else -> null
+    }
+
+private fun sessionErrorForGraphQlCategory(category: String?): SessionDomainError =
+    when (category?.lowercase()) {
+        "authentication" -> SessionDomainError.RegisteredSessionInvalid
+        "authorization" -> SessionDomainError.AuthorizationDenied
+        "validation" -> SessionDomainError.ValidationFailed
+        "conflict" -> SessionDomainError.Conflict
+        "dependency" -> SessionDomainError.DependencyUnavailable
+        "internal" -> SessionDomainError.Unexpected
+        "not_found" -> SessionDomainError.Unexpected
+        else -> SessionDomainError.Unexpected
+    }

--- a/client/core/session/internal/src/desktopMain/kotlin/dev/kigya/headway/core/session/domain/usecase/DesktopGoogleIdTokenAcquisition.kt
+++ b/client/core/session/internal/src/desktopMain/kotlin/dev/kigya/headway/core/session/domain/usecase/DesktopGoogleIdTokenAcquisition.kt
@@ -13,6 +13,8 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import java.awt.Desktop
+import java.awt.EventQueue
+import java.awt.Frame
 import java.net.HttpURLConnection
 import java.net.InetSocketAddress
 import java.net.URI
@@ -105,6 +107,7 @@ class DesktopGoogleIdTokenAcquisition(
             val params = parseQueryParams(rawQuery)
             if (params[QUERY_KEY_ERROR] != null) {
                 respondHtml(exchange, OAUTH_HTML_CLOSE_BODY)
+                bringDesktopAppToForeground()
                 onFinish(Outcome.failure(SessionDomainError.GoogleSignInCancelled))
                 return@runCatching
             }
@@ -112,6 +115,7 @@ class DesktopGoogleIdTokenAcquisition(
             val state = params[QUERY_KEY_STATE]
             if (code.isNullOrBlank() || state != expectedState) {
                 respondHtml(exchange, OAUTH_HTML_ERROR_BODY)
+                bringDesktopAppToForeground()
                 onFinish(Outcome.failure(SessionDomainError.GoogleSignInUnavailable))
                 return@runCatching
             }
@@ -122,15 +126,18 @@ class DesktopGoogleIdTokenAcquisition(
             )
             if (tokenOutcome is Outcome.Success) {
                 respondHtml(exchange, OAUTH_HTML_SUCCESS_BODY)
+                bringDesktopAppToForeground()
                 onFinish(Outcome.success(tokenOutcome.value))
             } else {
                 respondHtml(exchange, OAUTH_HTML_ERROR_BODY)
+                bringDesktopAppToForeground()
                 onFinish(tokenOutcome)
             }
         }.onFailure {
             runCatching {
                 respondHtml(exchange, OAUTH_HTML_ERROR_BODY)
             }
+            bringDesktopAppToForeground()
             onFinish(Outcome.failure(SessionDomainError.GoogleSignInUnavailable))
         }
     }
@@ -249,6 +256,26 @@ class DesktopGoogleIdTokenAcquisition(
     private fun codeChallengeS256(verifier: String): String {
         val digest = MessageDigest.getInstance(DIGEST_SHA256).digest(verifier.toByteArray(StandardCharsets.US_ASCII))
         return Base64.getUrlEncoder().withoutPadding().encodeToString(digest)
+    }
+
+    private fun bringDesktopAppToForeground() {
+        EventQueue.invokeLater {
+            runCatching {
+                val applicationClass = Class.forName("com.apple.eawt.Application")
+                val application = applicationClass.getMethod("getApplication").invoke(null)
+                applicationClass.getMethod("requestForeground", Boolean::class.javaPrimitiveType)
+                    .invoke(application, true)
+            }
+            for (frame in Frame.getFrames()) {
+                if (frame.isDisplayable && frame.isVisible) {
+                    if (frame.extendedState and Frame.ICONIFIED != 0) {
+                        frame.extendedState = Frame.NORMAL
+                    }
+                    frame.toFront()
+                    frame.requestFocus()
+                }
+            }
+        }
     }
 }
 

--- a/client/core/session/internal/src/desktopMain/kotlin/dev/kigya/headway/core/session/domain/usecase/DesktopGoogleIdTokenAcquisition.kt
+++ b/client/core/session/internal/src/desktopMain/kotlin/dev/kigya/headway/core/session/domain/usecase/DesktopGoogleIdTokenAcquisition.kt
@@ -1,0 +1,353 @@
+package dev.kigya.headway.core.session.domain.usecase
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.contract.GoogleIdTokenAcquisitionContract
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.awt.Desktop
+import java.net.HttpURLConnection
+import java.net.InetSocketAddress
+import java.net.URI
+import java.net.URLDecoder
+import java.net.URLEncoder
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+import java.util.concurrent.atomic.AtomicBoolean
+
+class DesktopGoogleIdTokenAcquisition(
+    private val ioDispatcher: CoroutineDispatcher,
+    private val googleOAuthClientSecret: String?,
+) : GoogleIdTokenAcquisitionContract {
+
+    override suspend fun obtainIdToken(): Outcome<SessionDomainError, String> =
+        withContext(ioDispatcher) {
+            withTimeoutOrNull(OAUTH_WAIT_TIMEOUT_MILLIS) {
+                suspendCancellableCoroutine<Outcome<SessionDomainError, String>> { continuation ->
+                    val finished = AtomicBoolean(false)
+                    var server: HttpServer? = null
+                    fun finishOnce(outcome: Outcome<SessionDomainError, String>) {
+                        if (!finished.compareAndSet(false, true)) {
+                            return
+                        }
+                        runCatching { server?.stop(SERVER_STOP_DELAY_SECONDS) }
+                        if (continuation.isActive) {
+                            continuation.resumeWith(Result.success(outcome))
+                        }
+                    }
+                    continuation.invokeOnCancellation {
+                        runCatching { server?.stop(SERVER_STOP_DELAY_SECONDS) }
+                    }
+                    val verifier = generateCodeVerifier()
+                    val challenge = codeChallengeS256(verifier)
+                    val state = randomUrlSafe(OAUTH_STATE_BYTE_LENGTH)
+                    val redirectUri = OAUTH_REDIRECT_URI
+                    val authUrl = buildAuthorizationUrl(
+                        clientId = GOOGLE_WEB_CLIENT_ID,
+                        redirectUri = redirectUri,
+                        codeChallenge = challenge,
+                        state = state,
+                    )
+                    val created = runCatching {
+                        HttpServer.create(
+                            InetSocketAddress(LOOPBACK_HOST, OAUTH_REDIRECT_PORT),
+                            SINGLE_CONNECTION_BACKLOG,
+                        )
+                    }.getOrElse {
+                        finishOnce(Outcome.failure(SessionDomainError.GoogleSignInUnavailable))
+                        return@suspendCancellableCoroutine
+                    }
+                    server = created
+                    created.createContext(OAUTH_REDIRECT_PATH) { exchange ->
+                        handleOAuthCallback(
+                            exchange = exchange,
+                            expectedState = state,
+                            codeVerifier = verifier,
+                            redirectUri = redirectUri,
+                            onFinish = ::finishOnce,
+                        )
+                    }
+                    created.executor = null
+                    created.start()
+                    val desktop = if (Desktop.isDesktopSupported()) Desktop.getDesktop() else null
+                    if (desktop == null || !desktop.isSupported(Desktop.Action.BROWSE)) {
+                        finishOnce(Outcome.failure(SessionDomainError.GoogleSignInUnavailable))
+                        return@suspendCancellableCoroutine
+                    }
+                    runCatching {
+                        desktop.browse(URI(authUrl))
+                    }.onFailure {
+                        finishOnce(Outcome.failure(SessionDomainError.GoogleSignInUnavailable))
+                    }
+                }
+            } ?: Outcome.failure(SessionDomainError.GoogleSignInCancelled)
+        }
+
+    private fun handleOAuthCallback(
+        exchange: HttpExchange,
+        expectedState: String,
+        codeVerifier: String,
+        redirectUri: String,
+        onFinish: (Outcome<SessionDomainError, String>) -> Unit,
+    ) {
+        runCatching {
+            val rawQuery = exchange.requestURI.rawQuery.orEmpty()
+            val params = parseQueryParams(rawQuery)
+            if (params[QUERY_KEY_ERROR] != null) {
+                respondHtml(exchange, OAUTH_HTML_CLOSE_BODY)
+                onFinish(Outcome.failure(SessionDomainError.GoogleSignInCancelled))
+                return@runCatching
+            }
+            val code = params[QUERY_KEY_CODE]
+            val state = params[QUERY_KEY_STATE]
+            if (code.isNullOrBlank() || state != expectedState) {
+                respondHtml(exchange, OAUTH_HTML_ERROR_BODY)
+                onFinish(Outcome.failure(SessionDomainError.GoogleSignInUnavailable))
+                return@runCatching
+            }
+            val tokenOutcome = exchangeCodeForIdToken(
+                code = code,
+                codeVerifier = codeVerifier,
+                redirectUri = redirectUri,
+            )
+            if (tokenOutcome is Outcome.Success) {
+                respondHtml(exchange, OAUTH_HTML_SUCCESS_BODY)
+                onFinish(Outcome.success(tokenOutcome.value))
+            } else {
+                respondHtml(exchange, OAUTH_HTML_ERROR_BODY)
+                onFinish(tokenOutcome)
+            }
+        }.onFailure {
+            runCatching {
+                respondHtml(exchange, OAUTH_HTML_ERROR_BODY)
+            }
+            onFinish(Outcome.failure(SessionDomainError.GoogleSignInUnavailable))
+        }
+    }
+
+    private fun respondHtml(
+        exchange: HttpExchange,
+        body: String,
+    ) {
+        val bytes = body.toByteArray(headwayUtf8Charset)
+        exchange.responseHeaders.set(HEADER_CONTENT_TYPE, CONTENT_TYPE_HTML_UTF8)
+        exchange.sendResponseHeaders(HTTP_OK, bytes.size.toLong())
+        exchange.responseBody.use { stream ->
+            stream.write(bytes)
+        }
+    }
+
+    private fun exchangeCodeForIdToken(
+        code: String,
+        codeVerifier: String,
+        redirectUri: String,
+    ): Outcome<SessionDomainError, String> = runCatching {
+        val connection = URI(TOKEN_ENDPOINT).toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = HTTP_METHOD_POST
+        connection.doOutput = true
+        connection.setRequestProperty(HEADER_CONTENT_TYPE, CONTENT_TYPE_FORM_URLENCODED)
+        val formPairs = buildList {
+            add(QUERY_KEY_CODE to code)
+            add(QUERY_KEY_CLIENT_ID to GOOGLE_WEB_CLIENT_ID)
+            add(QUERY_KEY_REDIRECT_URI to redirectUri)
+            add(QUERY_KEY_GRANT_TYPE to GRANT_TYPE_AUTHORIZATION_CODE)
+            add(QUERY_KEY_CODE_VERIFIER to codeVerifier)
+            val secret = googleOAuthClientSecret?.trim().orEmpty()
+            if (secret.isNotEmpty()) {
+                add(QUERY_KEY_CLIENT_SECRET to secret)
+            }
+        }
+        val body = formPairs.joinToString(separator = QUERY_PAIR_SEPARATOR) { (key, value) ->
+            "${URLEncoder.encode(key, headwayUtf8Charset)}" +
+                "${KEY_VALUE_SEPARATOR}${URLEncoder.encode(value, headwayUtf8Charset)}"
+        }
+        connection.outputStream.use { stream ->
+            stream.write(body.toByteArray(headwayUtf8Charset))
+        }
+        val status = connection.responseCode
+        val payloadStream = if (status in HTTP_STATUS_SUCCESS_MIN..HTTP_STATUS_SUCCESS_MAX) {
+            connection.inputStream
+        } else {
+            connection.errorStream ?: connection.inputStream
+        }
+        val responseText = payloadStream.use { stream ->
+            stream.readBytes().decodeToString()
+        }
+        val root = Json.parseToJsonElement(responseText) as? JsonObject
+        if (root == null) {
+            return Outcome.failure(SessionDomainError.GoogleSignInUnavailable)
+        }
+        val idToken = root[JSON_KEY_ID_TOKEN]?.jsonPrimitive?.content
+        if (idToken.isNullOrBlank()) {
+            Outcome.failure(SessionDomainError.GoogleSignInUnavailable)
+        } else {
+            Outcome.success(idToken)
+        }
+    }.getOrElse { Outcome.failure(SessionDomainError.GoogleSignInUnavailable) }
+
+    private fun buildAuthorizationUrl(
+        clientId: String,
+        redirectUri: String,
+        codeChallenge: String,
+        state: String,
+    ): String {
+        val enc = headwayUtf8Charset
+        return "$AUTH_ENDPOINT?" +
+            "${QUERY_KEY_CLIENT_ID}=${URLEncoder.encode(clientId, enc)}&" +
+            "${QUERY_KEY_REDIRECT_URI}=${URLEncoder.encode(redirectUri, enc)}&" +
+            "${QUERY_KEY_RESPONSE_TYPE}=$RESPONSE_TYPE_CODE&" +
+            "${QUERY_KEY_SCOPE}=${URLEncoder.encode(OAUTH_SCOPES, enc)}&" +
+            "${QUERY_KEY_CODE_CHALLENGE}=${URLEncoder.encode(codeChallenge, enc)}&" +
+            "${QUERY_KEY_CODE_CHALLENGE_METHOD}=$CHALLENGE_METHOD_S256&" +
+            "${QUERY_KEY_STATE}=${URLEncoder.encode(state, enc)}&" +
+            "${QUERY_KEY_PROMPT}=$PROMPT_SELECT_ACCOUNT"
+    }
+
+    private fun parseQueryParams(rawQuery: String): Map<String, String> {
+        if (rawQuery.isEmpty()) {
+            return emptyMap()
+        }
+        return rawQuery.split(QUERY_PAIR_SEPARATOR).asSequence()
+            .mapNotNull { pair ->
+                val idx = pair.indexOf(KEY_VALUE_SEPARATOR)
+                if (idx <= 0) {
+                    null
+                } else {
+                    val key = URLDecoder.decode(
+                        pair.substring(0, idx),
+                        headwayUtf8Charset,
+                    )
+                    val value = URLDecoder.decode(
+                        pair.substring(idx + 1),
+                        headwayUtf8Charset,
+                    )
+                    key to value
+                }
+            }
+            .toMap()
+    }
+
+    private fun generateCodeVerifier(): String = randomUrlSafe(CODE_VERIFIER_BYTE_LENGTH)
+
+    private fun randomUrlSafe(byteLength: Int): String {
+        val random = SecureRandom()
+        val bytes = ByteArray(byteLength)
+        random.nextBytes(bytes)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+
+    private fun codeChallengeS256(verifier: String): String {
+        val digest = MessageDigest.getInstance(DIGEST_SHA256).digest(verifier.toByteArray(StandardCharsets.US_ASCII))
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(digest)
+    }
+}
+
+private const val GOOGLE_WEB_CLIENT_ID: String =
+    "658272377808-alf63nc9km4tjgv0dr6lltfqfo1jshqb.apps.googleusercontent.com"
+
+private const val LOOPBACK_HOST: String = "127.0.0.1"
+
+private const val OAUTH_REDIRECT_PORT: Int = 8405
+
+private const val OAUTH_REDIRECT_PATH: String = "/oauth2callback"
+
+private const val OAUTH_REDIRECT_URI: String = "http://127.0.0.1:8405/oauth2callback"
+
+private const val AUTH_ENDPOINT: String = "https://accounts.google.com/o/oauth2/v2/auth"
+
+private const val TOKEN_ENDPOINT: String = "https://oauth2.googleapis.com/token"
+
+private const val OAUTH_SCOPES: String = "openid email profile"
+
+private const val OAUTH_CODE_VALUE: String = "code"
+
+private const val RESPONSE_TYPE_CODE: String = OAUTH_CODE_VALUE
+
+private const val CHALLENGE_METHOD_S256: String = "S256"
+
+private const val GRANT_TYPE_AUTHORIZATION_CODE: String = "authorization_code"
+
+private const val PROMPT_SELECT_ACCOUNT: String = "select_account"
+
+private const val QUERY_KEY_CODE: String = OAUTH_CODE_VALUE
+
+private const val QUERY_KEY_STATE: String = "state"
+
+private const val QUERY_KEY_ERROR: String = "error"
+
+private const val QUERY_KEY_CLIENT_ID: String = "client_id"
+
+private const val QUERY_KEY_REDIRECT_URI: String = "redirect_uri"
+
+private const val QUERY_KEY_RESPONSE_TYPE: String = "response_type"
+
+private const val QUERY_KEY_SCOPE: String = "scope"
+
+private const val QUERY_KEY_CODE_CHALLENGE: String = "code_challenge"
+
+private const val QUERY_KEY_CODE_CHALLENGE_METHOD: String = "code_challenge_method"
+
+private const val QUERY_KEY_PROMPT: String = "prompt"
+
+private const val QUERY_KEY_GRANT_TYPE: String = "grant_type"
+
+private const val QUERY_KEY_CODE_VERIFIER: String = "code_verifier"
+
+private const val QUERY_KEY_CLIENT_SECRET: String = "client_secret"
+
+private const val JSON_KEY_ID_TOKEN: String = "id_token"
+
+private const val HEADER_CONTENT_TYPE: String = "Content-Type"
+
+private const val CONTENT_TYPE_HTML_UTF8: String = "text/html; charset=UTF-8"
+
+private const val CONTENT_TYPE_FORM_URLENCODED: String = "application/x-www-form-urlencoded"
+
+private const val HTTP_OK: Int = 200
+
+private const val HTTP_STATUS_SUCCESS_MIN: Int = 200
+
+private const val HTTP_STATUS_SUCCESS_MAX: Int = 299
+
+private const val HTTP_METHOD_POST: String = "POST"
+
+private const val QUERY_PAIR_SEPARATOR: String = "&"
+
+private const val KEY_VALUE_SEPARATOR: Char = '='
+
+private const val OAUTH_STATE_BYTE_LENGTH: Int = 32
+
+private const val CODE_VERIFIER_BYTE_LENGTH: Int = 32
+
+private const val SINGLE_CONNECTION_BACKLOG: Int = 1
+
+private const val SERVER_STOP_DELAY_SECONDS: Int = 0
+
+private const val OAUTH_WAIT_TIMEOUT_MILLIS: Long = 300_000L
+
+private const val DIGEST_SHA256: String = "SHA-256"
+
+private const val OAUTH_HTML_DOC_PREFIX: String = "<!DOCTYPE html><html><body><p>"
+
+private const val OAUTH_HTML_DOC_SUFFIX: String = "</p></body></html>"
+
+private const val OAUTH_HTML_SUCCESS_BODY: String =
+    "${OAUTH_HTML_DOC_PREFIX}Sign-in complete. You can close this tab.$OAUTH_HTML_DOC_SUFFIX"
+
+private const val OAUTH_HTML_ERROR_BODY: String =
+    "${OAUTH_HTML_DOC_PREFIX}Sign-in failed. You can close this tab.$OAUTH_HTML_DOC_SUFFIX"
+
+private const val OAUTH_HTML_CLOSE_BODY: String =
+    "${OAUTH_HTML_DOC_PREFIX}You can close this tab.$OAUTH_HTML_DOC_SUFFIX"
+
+private val headwayUtf8Charset: Charset = StandardCharsets.UTF_8

--- a/client/core/storage/api/build.gradle.kts
+++ b/client/core/storage/api/build.gradle.kts
@@ -1,0 +1,11 @@
+import extension.commonMainDependencies
+
+plugins {
+    alias(libs.plugins.convention.base.sharedLibrary)
+}
+
+commonMainDependencies {
+    projects {
+        implementation(core.outcome)
+    }
+}

--- a/client/core/storage/api/src/commonMain/kotlin/dev/kigya/headway/core/secureStorage/SecureSessionStorageContract.kt
+++ b/client/core/storage/api/src/commonMain/kotlin/dev/kigya/headway/core/secureStorage/SecureSessionStorageContract.kt
@@ -1,0 +1,11 @@
+package dev.kigya.headway.core.secureStorage
+
+import dev.kigya.headway.core.outcome.Outcome
+
+interface SecureSessionStorageContract {
+    suspend fun loadPayload(): Outcome<SecureSessionStorageError, String?>
+
+    suspend fun savePayload(payload: String): Outcome<SecureSessionStorageError, Unit>
+
+    suspend fun clear(): Outcome<SecureSessionStorageError, Unit>
+}

--- a/client/core/storage/api/src/commonMain/kotlin/dev/kigya/headway/core/secureStorage/SecureSessionStorageError.kt
+++ b/client/core/storage/api/src/commonMain/kotlin/dev/kigya/headway/core/secureStorage/SecureSessionStorageError.kt
@@ -1,0 +1,7 @@
+package dev.kigya.headway.core.secureStorage
+
+sealed interface SecureSessionStorageError {
+    data class OperationFailed(
+        val cause: Throwable,
+    ) : SecureSessionStorageError
+}

--- a/client/core/storage/secure/build.gradle.kts
+++ b/client/core/storage/secure/build.gradle.kts
@@ -1,0 +1,31 @@
+import extension.androidMainDependencies
+import extension.commonMainDependencies
+import extension.wasmMainDependencies
+
+plugins {
+    alias(libs.plugins.convention.base.sharedLibrary)
+    alias(libs.plugins.convention.component.serialization)
+}
+
+commonMainDependencies {
+    projects {
+        implementation(core.outcome)
+        implementation(core.storageApi)
+    }
+    libs {
+        implementation(coroutines.core)
+        implementation(serializationJson)
+    }
+}
+
+androidMainDependencies {
+    libs {
+        implementation(dataStore.preferences)
+    }
+}
+
+wasmMainDependencies {
+    libs {
+        implementation(kotlinx.browser.wasm.js)
+    }
+}

--- a/client/core/storage/secure/src/androidMain/kotlin/dev/kigya/headway/core/secureStorage/AndroidSecureSessionStorage.kt
+++ b/client/core/storage/secure/src/androidMain/kotlin/dev/kigya/headway/core/secureStorage/AndroidSecureSessionStorage.kt
@@ -1,0 +1,69 @@
+package dev.kigya.headway.core.secureStorage
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.outcome.outcomeSuspendCatching
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+class AndroidSecureSessionStorage(
+    private val ioDispatcher: CoroutineDispatcher,
+    context: Context,
+    dataStoreScope: CoroutineScope,
+) : SecureSessionStorageContract {
+
+    private val applicationContext = context.applicationContext
+    private val cipher = AndroidSessionPayloadCipher()
+    private val dataStore: DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+            scope = dataStoreScope,
+            produceFile = { applicationContext.preferencesDataStoreFile(DATASTORE_FILE_NAME) },
+        )
+
+    override suspend fun loadPayload(): Outcome<SecureSessionStorageError, String?> =
+        outcomeSuspendCatching(
+            mapError = { SecureSessionStorageError.OperationFailed(it) },
+        ) {
+            withContext(ioDispatcher) {
+                val wrapped = dataStore.data.first()[payloadKey] ?: return@withContext null
+                cipher.decryptFromBase64(wrapped)
+            }
+        }
+
+    override suspend fun savePayload(payload: String): Outcome<SecureSessionStorageError, Unit> =
+        outcomeSuspendCatching(
+            mapError = { SecureSessionStorageError.OperationFailed(it) },
+        ) {
+            withContext(ioDispatcher) {
+                val wrapped = cipher.encryptToBase64(payload)
+                dataStore.edit { preferences ->
+                    preferences[payloadKey] = wrapped
+                }
+            }
+        }
+
+    @Suppress("FunctionSignature")
+    override suspend fun clear(): Outcome<SecureSessionStorageError, Unit> = outcomeSuspendCatching(
+        mapError = { SecureSessionStorageError.OperationFailed(it) },
+    ) {
+        withContext(ioDispatcher) {
+            dataStore.edit { preferences ->
+                preferences.remove(payloadKey)
+            }
+        }
+    }
+}
+
+private const val DATASTORE_FILE_NAME: String = "headway_secure_session"
+private val payloadKey = stringPreferencesKey("session_payload_enc")

--- a/client/core/storage/secure/src/androidMain/kotlin/dev/kigya/headway/core/secureStorage/AndroidSessionPayloadCipher.kt
+++ b/client/core/storage/secure/src/androidMain/kotlin/dev/kigya/headway/core/secureStorage/AndroidSessionPayloadCipher.kt
@@ -1,0 +1,63 @@
+package dev.kigya.headway.core.secureStorage
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+internal class AndroidSessionPayloadCipher {
+
+    private val secretKey: SecretKey
+        get() {
+            val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+            if (!keyStore.containsAlias(KEY_ALIAS)) {
+                val keyGenerator = KeyGenerator.getInstance(
+                    KeyProperties.KEY_ALGORITHM_AES,
+                    ANDROID_KEYSTORE,
+                )
+                val parameterSpec = KeyGenParameterSpec.Builder(
+                    KEY_ALIAS,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+                )
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .setKeySize(KEY_SIZE_BITS)
+                    .build()
+                keyGenerator.init(parameterSpec)
+                keyGenerator.generateKey()
+            }
+            return keyStore.getKey(KEY_ALIAS, null) as SecretKey
+        }
+
+    fun encryptToBase64(plainText: String): String {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey)
+        val iv = cipher.iv
+        val cipherBytes = cipher.doFinal(plainText.toByteArray(Charsets.UTF_8))
+        val combined = ByteArray(iv.size + cipherBytes.size)
+        System.arraycopy(iv, 0, combined, 0, iv.size)
+        System.arraycopy(cipherBytes, 0, combined, iv.size, cipherBytes.size)
+        return Base64.encodeToString(combined, Base64.NO_WRAP)
+    }
+
+    fun decryptFromBase64(wrapped: String): String? = runCatching {
+        val combined = Base64.decode(wrapped, Base64.NO_WRAP)
+        val iv = combined.copyOfRange(0, GCM_IV_LENGTH_BYTES)
+        val cipherText = combined.copyOfRange(GCM_IV_LENGTH_BYTES, combined.size)
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        val spec = GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv)
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, spec)
+        String(cipher.doFinal(cipherText), Charsets.UTF_8)
+    }.getOrNull()
+}
+
+private const val ANDROID_KEYSTORE: String = "AndroidKeyStore"
+private const val KEY_ALIAS: String = "headway.session.datastore.payload.v1"
+private const val TRANSFORMATION: String = "AES/GCM/NoPadding"
+private const val GCM_IV_LENGTH_BYTES: Int = 12
+private const val GCM_TAG_LENGTH_BITS: Int = 128
+private const val KEY_SIZE_BITS: Int = 256

--- a/client/core/storage/secure/src/desktopMain/kotlin/dev/kigya/headway/core/secureStorage/DesktopSecureSessionStorage.kt
+++ b/client/core/storage/secure/src/desktopMain/kotlin/dev/kigya/headway/core/secureStorage/DesktopSecureSessionStorage.kt
@@ -1,0 +1,57 @@
+package dev.kigya.headway.core.secureStorage
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.outcome.outcomeSuspendCatchingOn
+import kotlinx.coroutines.CoroutineDispatcher
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import kotlin.io.path.createDirectories
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.exists
+import kotlin.io.path.notExists
+
+class DesktopSecureSessionStorage(
+    private val ioDispatcher: CoroutineDispatcher,
+) : SecureSessionStorageContract {
+
+    private val storagePath: Path =
+        Path.of(System.getProperty("user.home"), ".headway", "session.enc")
+
+    override suspend fun loadPayload(): Outcome<SecureSessionStorageError, String?> =
+        outcomeSuspendCatchingOn(
+            dispatcher = ioDispatcher,
+            mapError = { SecureSessionStorageError.OperationFailed(it) },
+        ) {
+            if (storagePath.notExists()) {
+                null
+            } else {
+                Files.readString(storagePath)
+            }
+        }
+
+    override suspend fun savePayload(payload: String): Outcome<SecureSessionStorageError, Unit> =
+        outcomeSuspendCatchingOn(
+            dispatcher = ioDispatcher,
+            mapError = { SecureSessionStorageError.OperationFailed(it) },
+        ) {
+            storagePath.parent.createDirectories()
+            Files.writeString(
+                storagePath,
+                payload,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE,
+            )
+        }
+
+    override suspend fun clear(): Outcome<SecureSessionStorageError, Unit> =
+        outcomeSuspendCatchingOn(
+            dispatcher = ioDispatcher,
+            mapError = { SecureSessionStorageError.OperationFailed(it) },
+        ) {
+            if (storagePath.exists()) {
+                storagePath.deleteIfExists()
+            }
+        }
+}

--- a/client/core/storage/secure/src/iosMain/kotlin/dev/kigya/headway/core/secureStorage/IosSecureSessionStorage.kt
+++ b/client/core/storage/secure/src/iosMain/kotlin/dev/kigya/headway/core/secureStorage/IosSecureSessionStorage.kt
@@ -1,0 +1,39 @@
+package dev.kigya.headway.core.secureStorage
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.outcome.outcomeSuspendCatchingOn
+import kotlinx.coroutines.CoroutineDispatcher
+import platform.Foundation.NSUserDefaults
+
+class IosSecureSessionStorage(
+    private val ioDispatcher: CoroutineDispatcher,
+) : SecureSessionStorageContract {
+
+    private val defaults: NSUserDefaults = NSUserDefaults.standardUserDefaults
+
+    override suspend fun loadPayload(): Outcome<SecureSessionStorageError, String?> =
+        outcomeSuspendCatchingOn(
+            dispatcher = ioDispatcher,
+            mapError = { SecureSessionStorageError.OperationFailed(it) },
+        ) {
+            defaults.stringForKey(KEY_PAYLOAD)
+        }
+
+    override suspend fun savePayload(payload: String): Outcome<SecureSessionStorageError, Unit> =
+        outcomeSuspendCatchingOn(
+            dispatcher = ioDispatcher,
+            mapError = { SecureSessionStorageError.OperationFailed(it) },
+        ) {
+            defaults.setObject(payload, KEY_PAYLOAD)
+        }
+
+    override suspend fun clear(): Outcome<SecureSessionStorageError, Unit> =
+        outcomeSuspendCatchingOn(
+            dispatcher = ioDispatcher,
+            mapError = { SecureSessionStorageError.OperationFailed(it) },
+        ) {
+            defaults.removeObjectForKey(KEY_PAYLOAD)
+        }
+}
+
+private const val KEY_PAYLOAD: String = "headway_session_payload"

--- a/client/core/storage/secure/src/wasmJsMain/kotlin/dev/kigya/headway/core/secureStorage/WebSecureSessionStorage.kt
+++ b/client/core/storage/secure/src/wasmJsMain/kotlin/dev/kigya/headway/core/secureStorage/WebSecureSessionStorage.kt
@@ -1,0 +1,37 @@
+package dev.kigya.headway.core.secureStorage
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.outcome.outcomeSuspendCatchingOn
+import kotlinx.browser.localStorage
+import kotlinx.coroutines.CoroutineDispatcher
+
+class WebSecureSessionStorage(
+    private val ioDispatcher: CoroutineDispatcher,
+) : SecureSessionStorageContract {
+
+    override suspend fun loadPayload(): Outcome<SecureSessionStorageError, String?> =
+        outcomeSuspendCatchingOn(
+            dispatcher = ioDispatcher,
+            mapError = { SecureSessionStorageError.OperationFailed(it) },
+        ) {
+            localStorage.getItem(KEY_PAYLOAD)
+        }
+
+    override suspend fun savePayload(payload: String): Outcome<SecureSessionStorageError, Unit> =
+        outcomeSuspendCatchingOn(
+            dispatcher = ioDispatcher,
+            mapError = { SecureSessionStorageError.OperationFailed(it) },
+        ) {
+            localStorage.setItem(KEY_PAYLOAD, payload)
+        }
+
+    override suspend fun clear(): Outcome<SecureSessionStorageError, Unit> =
+        outcomeSuspendCatchingOn(
+            dispatcher = ioDispatcher,
+            mapError = { SecureSessionStorageError.OperationFailed(it) },
+        ) {
+            localStorage.removeItem(KEY_PAYLOAD)
+        }
+}
+
+private const val KEY_PAYLOAD: String = "headway_session_payload"

--- a/client/di/api/src/commonMain/kotlin/dev/kigya/headway/di/api/HeadwayGraphqlHttpUrl.kt
+++ b/client/di/api/src/commonMain/kotlin/dev/kigya/headway/di/api/HeadwayGraphqlHttpUrl.kt
@@ -1,0 +1,6 @@
+package dev.kigya.headway.di.api
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class HeadwayGraphqlHttpUrl(val value: String)

--- a/client/di/modules/build.gradle.kts
+++ b/client/di/modules/build.gradle.kts
@@ -1,4 +1,6 @@
+import extension.androidMainDependencies
 import extension.commonMainDependencies
+import extension.wasmMainDependencies
 
 plugins {
     alias(libs.plugins.convention.base.sharedLibrary)
@@ -10,9 +12,32 @@ plugins {
 
 commonMainDependencies {
     projects {
-        implementation(di.api)
-        implementation(feature.splash.di)
-        implementation(feature.auth.di)
-        implementation(navigation.di)
+        implementation(core.apollo)
+        implementation(core.networkApi)
+        implementation(core.storageApi)
+        implementation(core.storageSecure)
+        implementation(core.sessionInternal)
+        implementation(di.diApi)
+        implementation(feature.splashDi)
+        implementation(feature.authDi)
+        implementation(feature.homeDi)
+        implementation(feature.learnQuestionsDi)
+        implementation(navigation.navigationDi)
+    }
+    libs {
+        implementation(apollo.runtime)
+        implementation(koin.core)
+    }
+}
+
+androidMainDependencies {
+    libs {
+        implementation(koin.android)
+    }
+}
+
+wasmMainDependencies {
+    libs {
+        implementation(kotlinx.browser.wasm.js)
     }
 }

--- a/client/di/modules/src/androidMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.android.kt
+++ b/client/di/modules/src/androidMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.android.kt
@@ -1,0 +1,87 @@
+package dev.kigya.headway.di.api.module
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.provider.Settings
+import android.util.Log
+import dev.kigya.headway.core.secureStorage.AndroidSecureSessionStorage
+import dev.kigya.headway.core.secureStorage.SecureSessionStorageContract
+import dev.kigya.headway.core.session.domain.HeadwaySessionGatewayPlatform
+import dev.kigya.headway.core.session.domain.SessionRuntimeIdentityContract
+import dev.kigya.headway.di.api.DispatcherKey
+import dev.kigya.headway.di.api.HeadwayGraphqlHttpUrl
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.onClose
+import org.koin.core.module.dsl.withOptions
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+
+actual fun sessionPlatformModule(): Module = module {
+    single {
+        val url = resolveGraphqlHttpUrl(androidContext())
+        Log.i(HEADWAY_AUTH_LOG_TAG, "HeadwayGraphqlHttpUrl=$url")
+        HeadwayGraphqlHttpUrl(value = url)
+    }
+    single(
+        qualifier = named(HEADWAY_SECURE_SESSION_DATASTORE_SCOPE_NAME),
+    ) {
+        CoroutineScope(
+            SupervisorJob() + get<CoroutineDispatcher>(named(DispatcherKey.IO)),
+        )
+    }.withOptions {
+        onClose { scope: CoroutineScope? ->
+            scope?.cancel()
+        }
+    }
+    single<SecureSessionStorageContract> {
+        AndroidSecureSessionStorage(
+            context = androidContext(),
+            ioDispatcher = get(named(DispatcherKey.IO)),
+            dataStoreScope = get(named(HEADWAY_SECURE_SESSION_DATASTORE_SCOPE_NAME)),
+        )
+    }
+    single<SessionRuntimeIdentityContract> { AndroidSessionRuntimeIdentity(androidContext()) }
+}
+
+private fun resolveGraphqlHttpUrl(context: Context): String {
+    val applicationInfo = context.packageManager.getApplicationInfo(
+        context.packageName,
+        PackageManager.GET_META_DATA,
+    )
+    val fromManifest = applicationInfo.metaData?.getString(HEADWAY_GRAPHQL_HTTP_URL_META_KEY)?.trim()
+    return if (fromManifest.isNullOrEmpty()) {
+        DEFAULT_GRAPHQL_HTTP_URL
+    } else {
+        fromManifest
+    }
+}
+
+private class AndroidSessionRuntimeIdentity(
+    context: Context,
+) : SessionRuntimeIdentityContract {
+
+    private val applicationContext = context.applicationContext
+
+    override val deviceFingerprint: String
+        get() = Settings.Secure.getString(
+            applicationContext.contentResolver,
+            Settings.Secure.ANDROID_ID,
+        )
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?: "android-unknown"
+
+    override val sessionGatewayPlatform: HeadwaySessionGatewayPlatform = HeadwaySessionGatewayPlatform.Android
+}
+
+private const val HEADWAY_AUTH_LOG_TAG: String = "HeadwayAuth"
+
+private const val HEADWAY_GRAPHQL_HTTP_URL_META_KEY: String = "headway.graphql.httpUrl"
+private const val DEFAULT_GRAPHQL_HTTP_URL: String = "http://10.0.2.2:8080/api/v1/graphql"
+private const val HEADWAY_SECURE_SESSION_DATASTORE_SCOPE_NAME: String =
+    "HeadwaySecureSessionDataStoreScope"

--- a/client/di/modules/src/androidMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.android.kt
+++ b/client/di/modules/src/androidMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.android.kt
@@ -82,6 +82,6 @@ private class AndroidSessionRuntimeIdentity(
 private const val HEADWAY_AUTH_LOG_TAG: String = "HeadwayAuth"
 
 private const val HEADWAY_GRAPHQL_HTTP_URL_META_KEY: String = "headway.graphql.httpUrl"
-private const val DEFAULT_GRAPHQL_HTTP_URL: String = "http://10.0.2.2:8080/api/v1/graphql"
+private const val DEFAULT_GRAPHQL_HTTP_URL: String = "https://kigya-headway-dev-gateway.onrender.com/api/v1/graphql"
 private const val HEADWAY_SECURE_SESSION_DATASTORE_SCOPE_NAME: String =
     "HeadwaySecureSessionDataStoreScope"

--- a/client/di/modules/src/commonMain/kotlin/dev/kigya/headway/di/api/KoinModuleHolder.kt
+++ b/client/di/modules/src/commonMain/kotlin/dev/kigya/headway/di/api/KoinModuleHolder.kt
@@ -1,11 +1,18 @@
 package dev.kigya.headway.di.api
 
+import dev.kigya.headway.core.session.di.sessionDomainModule
 import dev.kigya.headway.di.api.module.dispatcherModule
 import dev.kigya.headway.di.api.module.featureModules
 import dev.kigya.headway.di.api.module.navigationModules
+import dev.kigya.headway.di.api.module.sessionInfrastructureModule
+import dev.kigya.headway.di.api.module.sessionPlatformModule
 import org.koin.core.module.Module
 
 val appModules: List<Module>
-    get() = featureModules +
+    get() = listOf(
+        sessionPlatformModule(),
+        sessionInfrastructureModule(),
+        sessionDomainModule(),
+    ) + featureModules +
         navigationModules +
         dispatcherModule

--- a/client/di/modules/src/commonMain/kotlin/dev/kigya/headway/di/api/module/FeatureModules.kt
+++ b/client/di/modules/src/commonMain/kotlin/dev/kigya/headway/di/api/module/FeatureModules.kt
@@ -3,6 +3,8 @@ package dev.kigya.headway.di.api.module
 import com.arkivanov.mvikotlin.core.store.StoreFactory
 import com.arkivanov.mvikotlin.main.store.DefaultStoreFactory
 import dev.kigya.headway.feature.auth.di.authModule
+import dev.kigya.headway.feature.home.di.homeModule
+import dev.kigya.headway.feature.learnQuestions.di.learnQuestionsModule
 import dev.kigya.headway.feature.splash.di.splashModule
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
@@ -18,5 +20,7 @@ val featureModules: List<Module>
             baseFeatureModule,
             splashModule,
             authModule,
+            homeModule,
+            learnQuestionsModule,
         )
     }

--- a/client/di/modules/src/commonMain/kotlin/dev/kigya/headway/di/api/module/SessionInfrastructureModule.kt
+++ b/client/di/modules/src/commonMain/kotlin/dev/kigya/headway/di/api/module/SessionInfrastructureModule.kt
@@ -1,0 +1,21 @@
+package dev.kigya.headway.di.api.module
+
+import com.apollographql.apollo.ApolloClient
+import dev.kigya.headway.core.apollo.HeadwayAccessTokenHolder
+import dev.kigya.headway.core.apollo.HeadwayGraphqlExecutor
+import dev.kigya.headway.core.apollo.createHeadwayApolloClient
+import dev.kigya.headway.core.network.api.HeadwayAccessTokenStore
+import dev.kigya.headway.core.network.api.HeadwayGraphqlOperationExecutor
+import dev.kigya.headway.di.api.HeadwayGraphqlHttpUrl
+import org.koin.dsl.module
+
+fun sessionInfrastructureModule() = module {
+    single<HeadwayAccessTokenStore> { HeadwayAccessTokenHolder() }
+    single<ApolloClient> {
+        createHeadwayApolloClient(
+            serverUrl = get<HeadwayGraphqlHttpUrl>().value,
+            accessTokenProvider = { get<HeadwayAccessTokenStore>().current() },
+        )
+    }
+    single<HeadwayGraphqlOperationExecutor> { HeadwayGraphqlExecutor(get()) }
+}

--- a/client/di/modules/src/commonMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.kt
+++ b/client/di/modules/src/commonMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.kt
@@ -1,0 +1,5 @@
+package dev.kigya.headway.di.api.module
+
+import org.koin.core.module.Module
+
+expect fun sessionPlatformModule(): Module

--- a/client/di/modules/src/desktopMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.desktop.kt
+++ b/client/di/modules/src/desktopMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.desktop.kt
@@ -1,0 +1,53 @@
+package dev.kigya.headway.di.api.module
+
+import dev.kigya.headway.core.secureStorage.DesktopSecureSessionStorage
+import dev.kigya.headway.core.secureStorage.SecureSessionStorageContract
+import dev.kigya.headway.core.session.domain.HeadwaySessionGatewayPlatform
+import dev.kigya.headway.core.session.domain.SessionRuntimeIdentityContract
+import dev.kigya.headway.core.session.domain.contract.GoogleIdTokenAcquisitionContract
+import dev.kigya.headway.core.session.domain.usecase.DesktopGoogleIdTokenAcquisition
+import dev.kigya.headway.di.api.DispatcherKey
+import dev.kigya.headway.di.api.HeadwayGraphqlHttpUrl
+import org.koin.core.module.Module
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.notExists
+import kotlin.random.Random
+
+actual fun sessionPlatformModule(): Module = module {
+    single { HeadwayGraphqlHttpUrl(DEV_GRAPHQL_URL) }
+    single<SecureSessionStorageContract> {
+        DesktopSecureSessionStorage(ioDispatcher = get(named(DispatcherKey.IO)))
+    }
+    single<SessionRuntimeIdentityContract> { DesktopSessionRuntimeIdentity() }
+    single<GoogleIdTokenAcquisitionContract> {
+        DesktopGoogleIdTokenAcquisition(
+            ioDispatcher = get(named(DispatcherKey.IO)),
+            googleOAuthClientSecret = "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",
+        )
+    }
+}
+
+private class DesktopSessionRuntimeIdentity : SessionRuntimeIdentityContract {
+
+    private val path: Path =
+        Path.of(System.getProperty("user.home"), ".headway", "device_fingerprint")
+
+    override val deviceFingerprint: String
+        get() {
+            if (path.notExists()) {
+                path.parent.createDirectories()
+                val value = "${Random.nextLong()}-${System.nanoTime()}"
+                Files.writeString(path, value)
+                return value
+            }
+            return Files.readString(path)
+        }
+
+    override val sessionGatewayPlatform: HeadwaySessionGatewayPlatform = HeadwaySessionGatewayPlatform.Desktop
+}
+
+private const val DEV_GRAPHQL_URL: String = "http://127.0.0.1:8080/api/v1/graphql"

--- a/client/di/modules/src/desktopMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.desktop.kt
+++ b/client/di/modules/src/desktopMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.desktop.kt
@@ -50,4 +50,4 @@ private class DesktopSessionRuntimeIdentity : SessionRuntimeIdentityContract {
     override val sessionGatewayPlatform: HeadwaySessionGatewayPlatform = HeadwaySessionGatewayPlatform.Desktop
 }
 
-private const val DEV_GRAPHQL_URL: String = "http://127.0.0.1:8080/api/v1/graphql"
+private const val DEV_GRAPHQL_URL: String = "https://kigya-headway-dev-gateway.onrender.com/api/v1/graphql"

--- a/client/di/modules/src/iosMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.ios.kt
+++ b/client/di/modules/src/iosMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.ios.kt
@@ -35,6 +35,6 @@ private class IosSessionRuntimeIdentity : SessionRuntimeIdentityContract {
     override val sessionGatewayPlatform: HeadwaySessionGatewayPlatform = HeadwaySessionGatewayPlatform.Ios
 }
 
-private const val DEV_GRAPHQL_URL: String = "http://127.0.0.1:8080/api/v1/graphql"
+private const val DEV_GRAPHQL_URL: String = "https://kigya-headway-dev-gateway.onrender.com/api/v1/graphql"
 
 private const val FINGERPRINT_KEY: String = "headway_device_fingerprint"

--- a/client/di/modules/src/iosMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.ios.kt
+++ b/client/di/modules/src/iosMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.ios.kt
@@ -1,0 +1,40 @@
+package dev.kigya.headway.di.api.module
+
+import dev.kigya.headway.core.secureStorage.IosSecureSessionStorage
+import dev.kigya.headway.core.secureStorage.SecureSessionStorageContract
+import dev.kigya.headway.core.session.domain.HeadwaySessionGatewayPlatform
+import dev.kigya.headway.core.session.domain.SessionRuntimeIdentityContract
+import dev.kigya.headway.di.api.DispatcherKey
+import dev.kigya.headway.di.api.HeadwayGraphqlHttpUrl
+import org.koin.core.module.Module
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+import platform.Foundation.NSUUID
+import platform.Foundation.NSUserDefaults
+
+actual fun sessionPlatformModule(): Module = module {
+    single { HeadwayGraphqlHttpUrl(DEV_GRAPHQL_URL) }
+    single<SecureSessionStorageContract> {
+        IosSecureSessionStorage(ioDispatcher = get(named(DispatcherKey.IO)))
+    }
+    single<SessionRuntimeIdentityContract> { IosSessionRuntimeIdentity() }
+}
+
+private class IosSessionRuntimeIdentity : SessionRuntimeIdentityContract {
+
+    private val defaults: NSUserDefaults = NSUserDefaults.standardUserDefaults
+
+    override val deviceFingerprint: String
+        get() {
+            defaults.stringForKey(FINGERPRINT_KEY)?.let { return it }
+            val created = NSUUID().UUIDString
+            defaults.setObject(created, FINGERPRINT_KEY)
+            return created
+        }
+
+    override val sessionGatewayPlatform: HeadwaySessionGatewayPlatform = HeadwaySessionGatewayPlatform.Ios
+}
+
+private const val DEV_GRAPHQL_URL: String = "http://127.0.0.1:8080/api/v1/graphql"
+
+private const val FINGERPRINT_KEY: String = "headway_device_fingerprint"

--- a/client/di/modules/src/webMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.web.kt
+++ b/client/di/modules/src/webMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.web.kt
@@ -35,5 +35,5 @@ private class WebSessionRuntimeIdentity : SessionRuntimeIdentityContract {
     override val sessionGatewayPlatform: HeadwaySessionGatewayPlatform = HeadwaySessionGatewayPlatform.Web
 }
 
-private const val DEV_GRAPHQL_URL: String = "http://127.0.0.1:8080/api/v1/graphql"
+private const val DEV_GRAPHQL_URL: String = "https://kigya-headway-dev-gateway.onrender.com/api/v1/graphql"
 private const val FINGERPRINT_KEY: String = "headway_device_fingerprint"

--- a/client/di/modules/src/webMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.web.kt
+++ b/client/di/modules/src/webMain/kotlin/dev/kigya/headway/di/api/module/SessionPlatformModule.web.kt
@@ -1,0 +1,39 @@
+package dev.kigya.headway.di.api.module
+
+import dev.kigya.headway.core.secureStorage.SecureSessionStorageContract
+import dev.kigya.headway.core.secureStorage.WebSecureSessionStorage
+import dev.kigya.headway.core.session.domain.HeadwaySessionGatewayPlatform
+import dev.kigya.headway.core.session.domain.SessionRuntimeIdentityContract
+import dev.kigya.headway.core.session.domain.contract.GoogleIdTokenAcquisitionContract
+import dev.kigya.headway.di.api.DispatcherKey
+import dev.kigya.headway.di.api.HeadwayGraphqlHttpUrl
+import kotlinx.browser.localStorage
+import org.koin.core.module.Module
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+import kotlin.random.Random
+
+actual fun sessionPlatformModule(): Module = module {
+    single { HeadwayGraphqlHttpUrl(DEV_GRAPHQL_URL) }
+    single<SecureSessionStorageContract> {
+        WebSecureSessionStorage(ioDispatcher = get(named(DispatcherKey.IO)))
+    }
+    single<SessionRuntimeIdentityContract> { WebSessionRuntimeIdentity() }
+    single<GoogleIdTokenAcquisitionContract> { WasmGoogleIdTokenAcquisition() }
+}
+
+private class WebSessionRuntimeIdentity : SessionRuntimeIdentityContract {
+
+    override val deviceFingerprint: String
+        get() {
+            localStorage.getItem(FINGERPRINT_KEY)?.let { return it }
+            val created = "${Random.nextLong()}-${Random.nextLong()}"
+            localStorage.setItem(FINGERPRINT_KEY, created)
+            return created
+        }
+
+    override val sessionGatewayPlatform: HeadwaySessionGatewayPlatform = HeadwaySessionGatewayPlatform.Web
+}
+
+private const val DEV_GRAPHQL_URL: String = "http://127.0.0.1:8080/api/v1/graphql"
+private const val FINGERPRINT_KEY: String = "headway_device_fingerprint"

--- a/client/di/modules/src/webMain/kotlin/dev/kigya/headway/di/api/module/WasmGoogleIdTokenAcquisition.kt
+++ b/client/di/modules/src/webMain/kotlin/dev/kigya/headway/di/api/module/WasmGoogleIdTokenAcquisition.kt
@@ -1,0 +1,58 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
+package dev.kigya.headway.di.api.module
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.contract.GoogleIdTokenAcquisitionContract
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.js.JsAny
+import kotlin.js.Promise
+import kotlin.js.js
+import kotlin.js.unsafeCast
+
+internal class WasmGoogleIdTokenAcquisition : GoogleIdTokenAcquisitionContract {
+
+    override suspend fun obtainIdToken(): Outcome<SessionDomainError, String> {
+        val credential = awaitGoogleCredentialOrNull()
+        return if (credential.isNullOrBlank()) {
+            Outcome.failure(SessionDomainError.GoogleSignInUnavailable)
+        } else {
+            Outcome.success(credential)
+        }
+    }
+
+    private suspend fun awaitGoogleCredentialOrNull(): String? =
+        suspendCancellableCoroutine { continuation ->
+            val promise = runCatching {
+                headwayBrowserWindow().headwayStartGoogleCredentialFlow(GOOGLE_WEB_CLIENT_ID)
+            }.getOrElse {
+                continuation.resume(null)
+                return@suspendCancellableCoroutine
+            }
+            promise.then(
+                onFulfilled = { value: JsAny? ->
+                    val text = value?.toString()
+                    continuation.resume(text)
+                    null
+                },
+                onRejected = { _: JsAny? ->
+                    continuation.resume(null)
+                    null
+                },
+            )
+        }
+}
+
+private external interface HeadwayWindowExport : JsAny {
+    fun headwayStartGoogleCredentialFlow(clientId: String): Promise<JsAny?>
+}
+
+private fun headwayWasmGlobalWindow(): JsAny = js("window")
+
+private fun headwayBrowserWindow(): HeadwayWindowExport =
+    headwayWasmGlobalWindow().unsafeCast<HeadwayWindowExport>()
+
+private const val GOOGLE_WEB_CLIENT_ID: String =
+    "658272377808-alf63nc9km4tjgv0dr6lltfqfo1jshqb.apps.googleusercontent.com"

--- a/client/feature/auth/api/build.gradle.kts
+++ b/client/feature/auth/api/build.gradle.kts
@@ -10,6 +10,6 @@ plugins {
 
 commonMainDependencies {
     projects {
-        implementation(navigation.api)
+        implementation(navigation.navigationApi)
     }
 }

--- a/client/feature/auth/di/build.gradle.kts
+++ b/client/feature/auth/di/build.gradle.kts
@@ -10,8 +10,9 @@ plugins {
 
 commonMainDependencies {
     projects {
-        implementation(navigation.api)
-        implementation(feature.auth.api)
-        implementation(feature.auth.internal)
+        implementation(core.sessionInternal)
+        implementation(navigation.navigationApi)
+        implementation(feature.authApi)
+        implementation(feature.authInternal)
     }
 }

--- a/client/feature/auth/internal/build.gradle.kts
+++ b/client/feature/auth/internal/build.gradle.kts
@@ -10,10 +10,19 @@ plugins {
     alias(libs.plugins.convention.component.mvi)
 }
 
+compose {
+    resources {
+        packageOfResClass = "headway.feature.auth.internal.generated.resources"
+    }
+}
+
 commonMainDependencies {
     projects {
-        implementation(navigation.api)
+        implementation(core.sessionInternal)
+        implementation(navigation.navigationApi)
         implementation(core.designSystem)
-        implementation(feature.auth.api)
+        implementation(feature.authApi)
+        implementation(feature.homeApi)
+        implementation(feature.learnQuestionsApi)
     }
 }

--- a/client/feature/auth/internal/src/commonMain/kotlin/dev/kigya/headway/feature/auth/internal/ui/screen/access/AuthNoAccessScreen.kt
+++ b/client/feature/auth/internal/src/commonMain/kotlin/dev/kigya/headway/feature/auth/internal/ui/screen/access/AuthNoAccessScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -191,18 +192,25 @@ private fun WideNoAccessLayout(lottieColumnWidth: Dp) {
     ) {
         AuthSideBySideLottieColumn(
             lottieColumnWidth = lottieColumnWidth,
-            modifier = Modifier.background(
-                color = AuthNoAccessTheme.colorScheme.cardBackgroundWide,
-                pattern = FreudBackgroundPattern.None,
-            ),
         ) {
-            NoAccessLottie(
+            Box(
                 modifier = Modifier
+                    .align(alignment = Alignment.BottomStart)
                     .fillMaxHeight()
-                    .fillMaxWidth(),
-                alignment = Alignment.BottomStart,
-                contentScale = ContentScale.FillHeight,
-            )
+                    .wrapContentWidth(align = Alignment.Start)
+                    .background(
+                        color = AuthNoAccessTheme.colorScheme.cardBackgroundWide,
+                        pattern = FreudBackgroundPattern.None,
+                    ),
+            ) {
+                NoAccessLottie(
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .wrapContentWidth(align = Alignment.Start),
+                    alignment = Alignment.BottomStart,
+                    contentScale = ContentScale.FillHeight,
+                )
+            }
         }
 
         Box(

--- a/client/feature/auth/internal/src/commonMain/kotlin/dev/kigya/headway/feature/auth/internal/ui/screen/auth/AuthScreen.kt
+++ b/client/feature/auth/internal/src/commonMain/kotlin/dev/kigya/headway/feature/auth/internal/ui/screen/auth/AuthScreen.kt
@@ -1,6 +1,5 @@
 package dev.kigya.headway.feature.auth.internal.ui.screen.auth
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -77,7 +76,9 @@ internal fun AuthScreen() {
 
     AuthScreenContent(
         state = state,
-        onOpenNoAccess = viewModel::onOpenNoAccess,
+        onSignInWithGoogle = viewModel::onSignInWithGoogle,
+        onContinueAsGuest = viewModel::onContinueAsGuest,
+        onDismissError = viewModel::onDismissError,
     )
 }
 
@@ -85,13 +86,14 @@ internal fun AuthScreen() {
 @Composable
 private fun AuthScreenContent(
     state: State<AuthStore.State>,
-    onOpenNoAccess: () -> Unit,
+    onSignInWithGoogle: () -> Unit,
+    onContinueAsGuest: () -> Unit,
+    onDismissError: () -> Unit,
 ) {
     val windowSizeClass = rememberWindowSizeClass()
     BoxWithConstraints(
         modifier = Modifier
             .fillMaxSize()
-            .clickable { onOpenNoAccess() }
             .background(
                 color = AuthTheme.colorScheme.authBackground,
                 pattern = FreudBackgroundPattern.Waves,
@@ -106,20 +108,35 @@ private fun AuthScreenContent(
             textColumnHorizontalPadding = horizontalPaddingWide,
         )
         FreudFallback(
-            isError = false,
-            onRetry = { },
+            isError = state.value.hasError,
+            onRetry = onDismissError,
         ) {
             if (useSideBySide) {
-                AuthScreenWideContent(lottieColumnWidth = lottieSideBudget)
+                AuthScreenWideContent(
+                    lottieColumnWidth = lottieSideBudget,
+                    isBusy = state.value.isBusy,
+                    onSignInWithGoogle = onSignInWithGoogle,
+                    onContinueAsGuest = onContinueAsGuest,
+                )
             } else {
-                AuthScreenStackedContent(containerWidth = maxWidth)
+                AuthScreenStackedContent(
+                    containerWidth = maxWidth,
+                    isBusy = state.value.isBusy,
+                    onSignInWithGoogle = onSignInWithGoogle,
+                    onContinueAsGuest = onContinueAsGuest,
+                )
             }
         }
     }
 }
 
 @Composable
-private fun AuthScreenStackedContent(containerWidth: Dp) {
+private fun AuthScreenStackedContent(
+    containerWidth: Dp,
+    isBusy: Boolean,
+    onSignInWithGoogle: () -> Unit,
+    onContinueAsGuest: () -> Unit,
+) {
     val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
@@ -152,6 +169,9 @@ private fun AuthScreenStackedContent(containerWidth: Dp) {
         }
         FreudSpacer(size = AuthTheme.dimension.dp36)
         AuthActionButtons(
+            isBusy = isBusy,
+            onSignInWithGoogle = onSignInWithGoogle,
+            onContinueAsGuest = onContinueAsGuest,
             modifier = Modifier
                 .widthIn(max = authSideBySideActionButtonWidth)
                 .fillMaxWidth(),
@@ -161,7 +181,12 @@ private fun AuthScreenStackedContent(containerWidth: Dp) {
 }
 
 @Composable
-private fun AuthScreenWideContent(lottieColumnWidth: Dp) {
+private fun AuthScreenWideContent(
+    lottieColumnWidth: Dp,
+    isBusy: Boolean,
+    onSignInWithGoogle: () -> Unit,
+    onContinueAsGuest: () -> Unit,
+) {
     Row(modifier = Modifier.fillMaxSize()) {
         AuthSideBySideLottieColumn(lottieColumnWidth = lottieColumnWidth) {
             FreudLottie(
@@ -188,7 +213,12 @@ private fun AuthScreenWideContent(lottieColumnWidth: Dp) {
             FreudSpacer(size = AuthTheme.dimension.dp36)
             AuthHeaderTexts(isWide = true)
             FreudSpacer(size = AuthTheme.dimension.dp48)
-            AuthActionButtons(modifier = Modifier.width(width = authSideBySideActionButtonWidth))
+            AuthActionButtons(
+                isBusy = isBusy,
+                onSignInWithGoogle = onSignInWithGoogle,
+                onContinueAsGuest = onContinueAsGuest,
+                modifier = Modifier.width(width = authSideBySideActionButtonWidth),
+            )
         }
     }
 }
@@ -258,25 +288,32 @@ private fun AuthHeaderTexts(isWide: Boolean) {
 }
 
 @Composable
-private fun AuthActionButtons(modifier: Modifier = Modifier) {
+private fun AuthActionButtons(
+    isBusy: Boolean,
+    onSignInWithGoogle: () -> Unit,
+    onContinueAsGuest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Column(modifier = modifier) {
         FreudHorizontalButton(
             modifier = Modifier.fillMaxWidth(),
             text = FreudTextValue.text(resource = Res.string.auth_learn_as_guest_button),
-            onClick = { },
+            onClick = onContinueAsGuest,
             containerColor = AuthTheme.colorScheme.transparent,
             contentColor = AuthTheme.colorScheme.learnAsGuestButtonColor,
             borderColor = AuthTheme.colorScheme.learnAsGuestButtonColor,
             size = FreudHorizontalButtonSize.LARGE,
+            isEnabled = !isBusy,
         )
         FreudSpacer(size = AuthTheme.dimension.dp20)
         FreudHorizontalButton(
             modifier = Modifier.fillMaxWidth(),
             text = FreudTextValue.text(resource = Res.string.auth_sing_in_google_button),
-            onClick = { },
+            onClick = onSignInWithGoogle,
             containerColor = AuthTheme.colorScheme.googleSingInButtonColor,
             contentColor = AuthTheme.colorScheme.googleSingInButtonTextColor,
             size = FreudHorizontalButtonSize.LARGE,
+            isEnabled = !isBusy,
             leadingIcon = FreudButtonIconSpec.Static(
                 resource = Res.drawable.ic_google,
                 tint = null,

--- a/client/feature/auth/internal/src/commonMain/kotlin/dev/kigya/headway/feature/auth/internal/ui/screen/auth/AuthStore.kt
+++ b/client/feature/auth/internal/src/commonMain/kotlin/dev/kigya/headway/feature/auth/internal/ui/screen/auth/AuthStore.kt
@@ -6,47 +6,126 @@ import com.arkivanov.mvikotlin.core.store.Store
 import com.arkivanov.mvikotlin.core.store.StoreFactory
 import com.arkivanov.mvikotlin.extensions.coroutines.coroutineBootstrapper
 import com.arkivanov.mvikotlin.extensions.coroutines.coroutineExecutorFactory
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.outcome.getOrNull
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import dev.kigya.headway.core.session.domain.usecase.LoginAsGuestUseCase
+import dev.kigya.headway.core.session.domain.usecase.LoginWithGoogleUseCase
+import dev.kigya.headway.core.session.domain.usecase.ObtainGoogleIdTokenUseCase
 import dev.kigya.headway.feature.auth.api.AuthNoAccessScreenKey
 import dev.kigya.headway.feature.auth.internal.ui.screen.auth.AuthStore.Intent
 import dev.kigya.headway.feature.auth.internal.ui.screen.auth.AuthStore.Label
 import dev.kigya.headway.feature.auth.internal.ui.screen.auth.AuthStore.State
+import dev.kigya.headway.feature.home.api.HomeScreenKey
+import dev.kigya.headway.feature.learnQuestions.api.LearnQuestionsScreenKey
 import dev.kigya.headway.navigation.api.navigator.NavigationIntent
 import dev.kigya.headway.navigation.api.navigator.NavigatorContract
+import dev.kigya.headway.navigation.api.navigator.asNavigationAsyncRunner
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlin.jvm.JvmInline
 
 interface AuthStore : Store<Intent, State, Label> {
     sealed interface Intent {
-        data object OpenNoAccess : Intent
+        data object SignInWithGoogle : Intent
+        data object ContinueAsGuest : Intent
+        data object DismissError : Intent
     }
 
     sealed interface Label
 
     @Immutable
-    data class State(val shouldDisplayText: Boolean = false)
+    data class State(
+        val isBusy: Boolean = false,
+        val hasError: Boolean = false,
+    )
 }
 
 class AuthStoreFactory(
     private val storeFactory: StoreFactory,
     private val navigator: NavigatorContract,
+    private val obtainGoogleIdToken: ObtainGoogleIdTokenUseCase,
+    private val loginWithGoogle: LoginWithGoogleUseCase,
+    private val loginAsGuest: LoginAsGuestUseCase,
 ) {
     fun create(executorCoroutineScope: CoroutineScope): AuthStore = object :
         AuthStore,
         Store<Intent, State, Label>
-        by storeFactory.create<Intent, Action, Message, State, Label>(
+        by storeFactory.create<Intent, Action, AuthReducerMessage, State, Label>(
             name = this::class.simpleName,
             initialState = State(),
             bootstrapper = coroutineBootstrapper { },
             executorFactory = coroutineExecutorFactory(executorCoroutineScope.coroutineContext) {
-                onIntent<Intent.OpenNoAccess> {
-                    navigator.navigate(NavigationIntent.NavigateTo(AuthNoAccessScreenKey))
+                onIntent<Intent.DismissError> {
+                    dispatch(AuthReducerSetHasError(false))
+                }
+                onIntent<Intent.SignInWithGoogle> {
+                    launch {
+                        dispatch(AuthReducerSetBusy(true))
+                        dispatch(AuthReducerSetHasError(false))
+                        val tokenOutcome = obtainGoogleIdToken()
+                        val idToken = tokenOutcome.getOrNull()
+                        if (idToken == null) {
+                            dispatch(AuthReducerSetHasError(true))
+                            dispatch(AuthReducerSetBusy(false))
+                            return@launch
+                        }
+                        when (val signedIn = loginWithGoogle(idToken)) {
+                            is Outcome.Success ->
+                                navigator.navigate(
+                                    NavigationIntent.ReplaceTopBy(
+                                        screenNavigationKey = HomeScreenKey,
+                                        asyncRunner = { executorCoroutineScope.asNavigationAsyncRunner() },
+                                    ),
+                                )
+
+                            is Outcome.Failure ->
+                                if (signedIn.error == SessionDomainError.UserNotInvited) {
+                                    navigator.navigate(
+                                        NavigationIntent.NavigateTo(AuthNoAccessScreenKey),
+                                    )
+                                } else {
+                                    dispatch(AuthReducerSetHasError(true))
+                                }
+                        }
+                        dispatch(AuthReducerSetBusy(false))
+                    }
+                }
+                onIntent<Intent.ContinueAsGuest> {
+                    launch {
+                        dispatch(AuthReducerSetBusy(true))
+                        dispatch(AuthReducerSetHasError(false))
+                        when (loginAsGuest()) {
+                            is Outcome.Success ->
+                                navigator.navigate(
+                                    NavigationIntent.ReplaceTopBy(
+                                        screenNavigationKey = LearnQuestionsScreenKey,
+                                        asyncRunner = { executorCoroutineScope.asNavigationAsyncRunner() },
+                                    ),
+                                )
+
+                            is Outcome.Failure ->
+                                dispatch(AuthReducerSetHasError(true))
+                        }
+                        dispatch(AuthReducerSetBusy(false))
+                    }
                 }
             },
             reducer = Reducer { message ->
-                copy(shouldDisplayText = true)
+                when (message) {
+                    is AuthReducerSetBusy -> copy(isBusy = message.value)
+                    is AuthReducerSetHasError -> copy(hasError = message.value)
+                }
             },
         ) {}
 
     private sealed interface Action
-
-    private sealed interface Message
 }
+
+private sealed interface AuthReducerMessage
+
+@JvmInline
+private value class AuthReducerSetBusy(val value: Boolean) : AuthReducerMessage
+
+@JvmInline
+private value class AuthReducerSetHasError(val value: Boolean) : AuthReducerMessage

--- a/client/feature/auth/internal/src/commonMain/kotlin/dev/kigya/headway/feature/auth/internal/ui/screen/auth/AuthViewModel.kt
+++ b/client/feature/auth/internal/src/commonMain/kotlin/dev/kigya/headway/feature/auth/internal/ui/screen/auth/AuthViewModel.kt
@@ -4,21 +4,38 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arkivanov.mvikotlin.core.store.StoreFactory
 import com.arkivanov.mvikotlin.extensions.coroutines.stateFlow
+import dev.kigya.headway.core.session.domain.usecase.LoginAsGuestUseCase
+import dev.kigya.headway.core.session.domain.usecase.LoginWithGoogleUseCase
+import dev.kigya.headway.core.session.domain.usecase.ObtainGoogleIdTokenUseCase
 import dev.kigya.headway.navigation.api.navigator.NavigatorContract
 import kotlinx.coroutines.flow.StateFlow
 
 class AuthViewModel(
     storeFactory: StoreFactory,
     navigator: NavigatorContract,
+    obtainGoogleIdToken: ObtainGoogleIdTokenUseCase,
+    loginWithGoogle: LoginWithGoogleUseCase,
+    loginAsGuest: LoginAsGuestUseCase,
 ) : ViewModel() {
     private val store: AuthStore = AuthStoreFactory(
         storeFactory = storeFactory,
         navigator = navigator,
+        obtainGoogleIdToken = obtainGoogleIdToken,
+        loginWithGoogle = loginWithGoogle,
+        loginAsGuest = loginAsGuest,
     ).create(viewModelScope)
 
     val uiState: StateFlow<AuthStore.State> = store.stateFlow(viewModelScope)
 
-    fun onOpenNoAccess() {
-        store.accept(AuthStore.Intent.OpenNoAccess)
+    fun onSignInWithGoogle() {
+        store.accept(AuthStore.Intent.SignInWithGoogle)
+    }
+
+    fun onContinueAsGuest() {
+        store.accept(AuthStore.Intent.ContinueAsGuest)
+    }
+
+    fun onDismissError() {
+        store.accept(AuthStore.Intent.DismissError)
     }
 }

--- a/client/feature/home/api/build.gradle.kts
+++ b/client/feature/home/api/build.gradle.kts
@@ -1,0 +1,13 @@
+import extension.commonMainDependencies
+
+plugins {
+    alias(libs.plugins.convention.base.sharedLibrary)
+    alias(libs.plugins.convention.component.serialization)
+    alias(libs.plugins.convention.component.composeNavigation)
+}
+
+commonMainDependencies {
+    projects {
+        implementation(navigation.navigationApi)
+    }
+}

--- a/client/feature/home/api/src/commonMain/kotlin/dev/kigya/headway/feature/home/api/HomeRouteHolder.kt
+++ b/client/feature/home/api/src/commonMain/kotlin/dev/kigya/headway/feature/home/api/HomeRouteHolder.kt
@@ -1,0 +1,10 @@
+package dev.kigya.headway.feature.home.api
+
+import androidx.navigation3.runtime.NavKey
+import dev.kigya.headway.navigation.api.route.ScreenRouteHolderContract
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object HomeScreenKey : NavKey
+
+interface HomeScreenRouteHolderContract : ScreenRouteHolderContract

--- a/client/feature/home/di/build.gradle.kts
+++ b/client/feature/home/di/build.gradle.kts
@@ -1,0 +1,18 @@
+import extension.commonMainDependencies
+
+plugins {
+    alias(libs.plugins.convention.base.sharedLibrary)
+    alias(libs.plugins.convention.component.compose)
+    alias(libs.plugins.convention.component.koin)
+    alias(libs.plugins.convention.component.mvi)
+}
+
+commonMainDependencies {
+    projects {
+        implementation(core.sessionInternal)
+        implementation(di.diApi)
+        implementation(feature.homeApi)
+        implementation(feature.homeInternal)
+        implementation(navigation.navigationApi)
+    }
+}

--- a/client/feature/home/di/src/commonMain/kotlin/dev/kigya/headway/feature/home/di/HomeModule.kt
+++ b/client/feature/home/di/src/commonMain/kotlin/dev/kigya/headway/feature/home/di/HomeModule.kt
@@ -1,0 +1,18 @@
+package dev.kigya.headway.feature.home.di
+
+import dev.kigya.headway.feature.home.api.HomeScreenRouteHolderContract
+import dev.kigya.headway.feature.home.internal.ui.route.HomeScreenRouteHolder
+import dev.kigya.headway.feature.home.internal.ui.screen.HomeStoreFactory
+import dev.kigya.headway.feature.home.internal.ui.screen.HomeViewModel
+import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+val homeModule
+    get() = module {
+        factoryOf(::HomeStoreFactory)
+        viewModelOf(::HomeViewModel)
+        singleOf(::HomeScreenRouteHolder) bind HomeScreenRouteHolderContract::class
+    }

--- a/client/feature/home/internal/build.gradle.kts
+++ b/client/feature/home/internal/build.gradle.kts
@@ -1,0 +1,20 @@
+import extension.commonMainDependencies
+
+plugins {
+    alias(libs.plugins.convention.base.sharedLibrary)
+    alias(libs.plugins.convention.component.compose)
+    alias(libs.plugins.convention.component.serialization)
+    alias(libs.plugins.convention.component.composeNavigation)
+    alias(libs.plugins.convention.component.koin)
+    alias(libs.plugins.convention.component.mvi)
+}
+
+commonMainDependencies {
+    projects {
+        implementation(core.sessionInternal)
+        implementation(navigation.navigationApi)
+        implementation(core.designSystem)
+        implementation(feature.authApi)
+        implementation(feature.homeApi)
+    }
+}

--- a/client/feature/home/internal/src/commonMain/kotlin/dev/kigya/headway/feature/home/internal/ui/route/HomeScreenRouteHolder.kt
+++ b/client/feature/home/internal/src/commonMain/kotlin/dev/kigya/headway/feature/home/internal/ui/route/HomeScreenRouteHolder.kt
@@ -1,0 +1,12 @@
+package dev.kigya.headway.feature.home.internal.ui.route
+
+import androidx.compose.runtime.Composable
+import dev.kigya.headway.feature.home.api.HomeScreenKey
+import dev.kigya.headway.feature.home.api.HomeScreenRouteHolderContract
+import dev.kigya.headway.feature.home.internal.ui.screen.HomeScreen
+
+class HomeScreenRouteHolder : HomeScreenRouteHolderContract {
+    override val screenNavigationKey = HomeScreenKey
+
+    override val content = @Composable { HomeScreen() }
+}

--- a/client/feature/home/internal/src/commonMain/kotlin/dev/kigya/headway/feature/home/internal/ui/screen/HomeScreen.kt
+++ b/client/feature/home/internal/src/commonMain/kotlin/dev/kigya/headway/feature/home/internal/ui/screen/HomeScreen.kt
@@ -1,0 +1,80 @@
+package dev.kigya.headway.feature.home.internal.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.kigya.headway.core.designSystem.component.FreudFallback
+import dev.kigya.headway.core.designSystem.component.FreudHorizontalButton
+import dev.kigya.headway.core.designSystem.component.FreudHorizontalButtonSize
+import dev.kigya.headway.core.designSystem.component.FreudSpacer
+import dev.kigya.headway.core.designSystem.component.FreudText
+import dev.kigya.headway.core.designSystem.util.FreudScreenByWidth
+import dev.kigya.headway.core.designSystem.util.FreudTextValue
+import dev.kigya.headway.feature.home.internal.ui.theme.HomeTheme
+import dev.kigya.headway.feature.home.internal.ui.theme.HomeTheme.homeActionContainer
+import dev.kigya.headway.feature.home.internal.ui.theme.HomeTheme.homeActionContent
+import dev.kigya.headway.feature.home.internal.ui.theme.HomeTheme.homeBackground
+import dev.kigya.headway.feature.home.internal.ui.theme.HomeTheme.homePrimaryText
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+internal fun HomeScreen() {
+    val viewModel = koinViewModel<HomeViewModel>()
+    val state = viewModel.uiState.collectAsStateWithLifecycle()
+
+    HomeScreenContent(
+        state = state,
+        onSignOut = viewModel::onSignOut,
+        onRetryLoad = viewModel::onRetryLoad,
+    )
+}
+
+@Composable
+private fun HomeScreenContent(
+    state: State<HomeStore.State>,
+    onSignOut: () -> Unit,
+    onRetryLoad: () -> Unit,
+) {
+    val content: @Composable BoxScope.() -> Unit = {
+        FreudFallback(
+            isError = state.value.errorMessage != null,
+            onRetry = onRetryLoad,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(HomeTheme.colorScheme.homeBackground.value)
+                    .padding(HomeTheme.dimension.dp24.value),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                FreudText(
+                    value = FreudTextValue.text(state.value.greeting),
+                    color = HomeTheme.colorScheme.homePrimaryText,
+                    typography = HomeTheme.typography.headingSmExtraBold,
+                )
+                FreudSpacer(size = HomeTheme.dimension.dp24)
+                FreudHorizontalButton(
+                    text = FreudTextValue.text("Sign out"),
+                    onClick = onSignOut,
+                    containerColor = HomeTheme.colorScheme.homeActionContainer,
+                    contentColor = HomeTheme.colorScheme.homeActionContent,
+                    size = FreudHorizontalButtonSize.LARGE,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+
+    FreudScreenByWidth(
+        narrow = content,
+        wide = content,
+    )
+}

--- a/client/feature/home/internal/src/commonMain/kotlin/dev/kigya/headway/feature/home/internal/ui/screen/HomeStore.kt
+++ b/client/feature/home/internal/src/commonMain/kotlin/dev/kigya/headway/feature/home/internal/ui/screen/HomeStore.kt
@@ -1,0 +1,100 @@
+package dev.kigya.headway.feature.home.internal.ui.screen
+
+import androidx.compose.runtime.Immutable
+import com.arkivanov.mvikotlin.core.store.Reducer
+import com.arkivanov.mvikotlin.core.store.Store
+import com.arkivanov.mvikotlin.core.store.StoreFactory
+import com.arkivanov.mvikotlin.extensions.coroutines.coroutineBootstrapper
+import com.arkivanov.mvikotlin.extensions.coroutines.coroutineExecutorFactory
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.usecase.LoadHomeScreenSummaryUseCase
+import dev.kigya.headway.core.session.domain.usecase.LogoutRegisteredUseCase
+import dev.kigya.headway.feature.auth.api.AuthScreenKey
+import dev.kigya.headway.feature.home.internal.ui.screen.HomeStore.Intent
+import dev.kigya.headway.feature.home.internal.ui.screen.HomeStore.Label
+import dev.kigya.headway.feature.home.internal.ui.screen.HomeStore.State
+import dev.kigya.headway.navigation.api.navigator.NavigationIntent
+import dev.kigya.headway.navigation.api.navigator.NavigatorContract
+import dev.kigya.headway.navigation.api.navigator.asNavigationAsyncRunner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+interface HomeStore : Store<Intent, State, Label> {
+    sealed interface Intent {
+        data object SignOut : Intent
+        data object RetryLoad : Intent
+    }
+
+    sealed interface Label
+
+    @Immutable
+    data class State(
+        val greeting: String = "",
+        val errorMessage: String? = null,
+    )
+}
+
+class HomeStoreFactory(
+    private val storeFactory: StoreFactory,
+    private val navigator: NavigatorContract,
+    private val loadHomeScreenSummary: LoadHomeScreenSummaryUseCase,
+    private val logoutRegistered: LogoutRegisteredUseCase,
+) {
+    fun create(executorCoroutineScope: CoroutineScope): HomeStore = object :
+        HomeStore,
+        Store<Intent, State, Label>
+        by storeFactory.create<Intent, Action, Message, State, Label>(
+            name = this::class.simpleName,
+            initialState = State(),
+            bootstrapper = coroutineBootstrapper {
+                dispatch(Action.LoadHomeSummary)
+            },
+            executorFactory = coroutineExecutorFactory(executorCoroutineScope.coroutineContext) {
+                onAction<Action.LoadHomeSummary> {
+                    launch {
+                        when (val summary = loadHomeScreenSummary()) {
+                            is Outcome.Success -> dispatch(Message.GreetingLoaded(summary.value.greeting))
+                            is Outcome.Failure -> dispatch(Message.LoadFailed)
+                        }
+                    }
+                }
+                onIntent<Intent.RetryLoad> {
+                    dispatch(Message.ClearError)
+                    launch {
+                        when (val summary = loadHomeScreenSummary()) {
+                            is Outcome.Success -> dispatch(Message.GreetingLoaded(summary.value.greeting))
+                            is Outcome.Failure -> dispatch(Message.LoadFailed)
+                        }
+                    }
+                }
+                onIntent<Intent.SignOut> {
+                    launch {
+                        logoutRegistered()
+                        navigator.navigate(
+                            NavigationIntent.ReplaceTopBy(
+                                screenNavigationKey = AuthScreenKey,
+                                asyncRunner = { executorCoroutineScope.asNavigationAsyncRunner() },
+                            ),
+                        )
+                    }
+                }
+            },
+            reducer = Reducer { message ->
+                when (message) {
+                    is Message.GreetingLoaded -> copy(greeting = message.value, errorMessage = null)
+                    Message.LoadFailed -> copy(errorMessage = "Could not load home.")
+                    Message.ClearError -> copy(errorMessage = null)
+                }
+            },
+        ) {}
+
+    private sealed interface Action {
+        data object LoadHomeSummary : Action
+    }
+
+    private sealed interface Message {
+        data class GreetingLoaded(val value: String) : Message
+        data object LoadFailed : Message
+        data object ClearError : Message
+    }
+}

--- a/client/feature/home/internal/src/commonMain/kotlin/dev/kigya/headway/feature/home/internal/ui/screen/HomeViewModel.kt
+++ b/client/feature/home/internal/src/commonMain/kotlin/dev/kigya/headway/feature/home/internal/ui/screen/HomeViewModel.kt
@@ -1,0 +1,35 @@
+package dev.kigya.headway.feature.home.internal.ui.screen
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.arkivanov.mvikotlin.core.store.StoreFactory
+import com.arkivanov.mvikotlin.extensions.coroutines.stateFlow
+import dev.kigya.headway.core.session.domain.usecase.LoadHomeScreenSummaryUseCase
+import dev.kigya.headway.core.session.domain.usecase.LogoutRegisteredUseCase
+import dev.kigya.headway.navigation.api.navigator.NavigatorContract
+import kotlinx.coroutines.flow.StateFlow
+
+class HomeViewModel(
+    storeFactory: StoreFactory,
+    navigator: NavigatorContract,
+    loadHomeScreenSummary: LoadHomeScreenSummaryUseCase,
+    logoutRegistered: LogoutRegisteredUseCase,
+) : ViewModel() {
+
+    private val store: HomeStore = HomeStoreFactory(
+        storeFactory = storeFactory,
+        navigator = navigator,
+        loadHomeScreenSummary = loadHomeScreenSummary,
+        logoutRegistered = logoutRegistered,
+    ).create(viewModelScope)
+
+    val uiState: StateFlow<HomeStore.State> = store.stateFlow(viewModelScope)
+
+    fun onSignOut() {
+        store.accept(HomeStore.Intent.SignOut)
+    }
+
+    fun onRetryLoad() {
+        store.accept(HomeStore.Intent.RetryLoad)
+    }
+}

--- a/client/feature/home/internal/src/commonMain/kotlin/dev/kigya/headway/feature/home/internal/ui/theme/HomeTheme.kt
+++ b/client/feature/home/internal/src/commonMain/kotlin/dev/kigya/headway/feature/home/internal/ui/theme/HomeTheme.kt
@@ -1,0 +1,37 @@
+package dev.kigya.headway.feature.home.internal.ui.theme
+
+import androidx.compose.runtime.Composable
+import dev.kigya.headway.core.designSystem.theme.FreudTheme
+import dev.kigya.headway.core.designSystem.theme.color.FreudColorScheme
+import dev.kigya.headway.core.designSystem.theme.color.FreudDynamicColor
+import dev.kigya.headway.core.designSystem.theme.color.provides
+
+internal object HomeTheme : FreudTheme() {
+    val FreudColorScheme.homeBackground
+        @Composable
+        get() = this provides FreudDynamicColor(
+            light = super.color.brown10,
+            dark = super.color.brown100,
+        )
+
+    val FreudColorScheme.homePrimaryText
+        @Composable
+        get() = this provides FreudDynamicColor(
+            light = super.color.brown90,
+            dark = super.color.brown40,
+        )
+
+    val FreudColorScheme.homeActionContainer
+        @Composable
+        get() = this provides FreudDynamicColor(
+            light = super.color.brown80,
+            dark = super.color.brown40,
+        )
+
+    val FreudColorScheme.homeActionContent
+        @Composable
+        get() = this provides FreudDynamicColor(
+            light = super.color.brown10,
+            dark = super.color.brown100,
+        )
+}

--- a/client/feature/learn-questions/api/build.gradle.kts
+++ b/client/feature/learn-questions/api/build.gradle.kts
@@ -1,0 +1,13 @@
+import extension.commonMainDependencies
+
+plugins {
+    alias(libs.plugins.convention.base.sharedLibrary)
+    alias(libs.plugins.convention.component.serialization)
+    alias(libs.plugins.convention.component.composeNavigation)
+}
+
+commonMainDependencies {
+    projects {
+        implementation(navigation.navigationApi)
+    }
+}

--- a/client/feature/learn-questions/api/src/commonMain/kotlin/dev/kigya/headway/feature/learnQuestions/api/LearnQuestionsRouteHolder.kt
+++ b/client/feature/learn-questions/api/src/commonMain/kotlin/dev/kigya/headway/feature/learnQuestions/api/LearnQuestionsRouteHolder.kt
@@ -1,0 +1,10 @@
+package dev.kigya.headway.feature.learnQuestions.api
+
+import androidx.navigation3.runtime.NavKey
+import dev.kigya.headway.navigation.api.route.ScreenRouteHolderContract
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object LearnQuestionsScreenKey : NavKey
+
+interface LearnQuestionsScreenRouteHolderContract : ScreenRouteHolderContract

--- a/client/feature/learn-questions/di/build.gradle.kts
+++ b/client/feature/learn-questions/di/build.gradle.kts
@@ -1,0 +1,18 @@
+import extension.commonMainDependencies
+
+plugins {
+    alias(libs.plugins.convention.base.sharedLibrary)
+    alias(libs.plugins.convention.component.compose)
+    alias(libs.plugins.convention.component.koin)
+    alias(libs.plugins.convention.component.mvi)
+}
+
+commonMainDependencies {
+    projects {
+        implementation(core.sessionInternal)
+        implementation(di.diApi)
+        implementation(feature.learnQuestionsApi)
+        implementation(feature.learnQuestionsInternal)
+        implementation(navigation.navigationApi)
+    }
+}

--- a/client/feature/learn-questions/di/src/commonMain/kotlin/dev/kigya/headway/feature/learnQuestions/di/LearnQuestionsModule.kt
+++ b/client/feature/learn-questions/di/src/commonMain/kotlin/dev/kigya/headway/feature/learnQuestions/di/LearnQuestionsModule.kt
@@ -1,0 +1,18 @@
+package dev.kigya.headway.feature.learnQuestions.di
+
+import dev.kigya.headway.feature.learnQuestions.api.LearnQuestionsScreenRouteHolderContract
+import dev.kigya.headway.feature.learnQuestions.internal.ui.route.LearnQuestionsScreenRouteHolder
+import dev.kigya.headway.feature.learnQuestions.internal.ui.screen.LearnQuestionsStoreFactory
+import dev.kigya.headway.feature.learnQuestions.internal.ui.screen.LearnQuestionsViewModel
+import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+val learnQuestionsModule
+    get() = module {
+        factoryOf(::LearnQuestionsStoreFactory)
+        viewModelOf(::LearnQuestionsViewModel)
+        singleOf(::LearnQuestionsScreenRouteHolder) bind LearnQuestionsScreenRouteHolderContract::class
+    }

--- a/client/feature/learn-questions/internal/build.gradle.kts
+++ b/client/feature/learn-questions/internal/build.gradle.kts
@@ -1,0 +1,20 @@
+import extension.commonMainDependencies
+
+plugins {
+    alias(libs.plugins.convention.base.sharedLibrary)
+    alias(libs.plugins.convention.component.compose)
+    alias(libs.plugins.convention.component.serialization)
+    alias(libs.plugins.convention.component.composeNavigation)
+    alias(libs.plugins.convention.component.koin)
+    alias(libs.plugins.convention.component.mvi)
+}
+
+commonMainDependencies {
+    projects {
+        implementation(core.sessionInternal)
+        implementation(navigation.navigationApi)
+        implementation(core.designSystem)
+        implementation(feature.authApi)
+        implementation(feature.learnQuestionsApi)
+    }
+}

--- a/client/feature/learn-questions/internal/src/commonMain/kotlin/dev/kigya/headway/feature/learnQuestions/internal/ui/route/LearnQuestionsScreenRouteHolder.kt
+++ b/client/feature/learn-questions/internal/src/commonMain/kotlin/dev/kigya/headway/feature/learnQuestions/internal/ui/route/LearnQuestionsScreenRouteHolder.kt
@@ -1,0 +1,12 @@
+package dev.kigya.headway.feature.learnQuestions.internal.ui.route
+
+import androidx.compose.runtime.Composable
+import dev.kigya.headway.feature.learnQuestions.api.LearnQuestionsScreenKey
+import dev.kigya.headway.feature.learnQuestions.api.LearnQuestionsScreenRouteHolderContract
+import dev.kigya.headway.feature.learnQuestions.internal.ui.screen.LearnQuestionsScreen
+
+class LearnQuestionsScreenRouteHolder : LearnQuestionsScreenRouteHolderContract {
+    override val screenNavigationKey = LearnQuestionsScreenKey
+
+    override val content = @Composable { LearnQuestionsScreen() }
+}

--- a/client/feature/learn-questions/internal/src/commonMain/kotlin/dev/kigya/headway/feature/learnQuestions/internal/ui/screen/LearnQuestionsScreen.kt
+++ b/client/feature/learn-questions/internal/src/commonMain/kotlin/dev/kigya/headway/feature/learnQuestions/internal/ui/screen/LearnQuestionsScreen.kt
@@ -1,0 +1,86 @@
+package dev.kigya.headway.feature.learnQuestions.internal.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.kigya.headway.core.designSystem.component.FreudFallback
+import dev.kigya.headway.core.designSystem.component.FreudHorizontalButton
+import dev.kigya.headway.core.designSystem.component.FreudHorizontalButtonSize
+import dev.kigya.headway.core.designSystem.component.FreudSpacer
+import dev.kigya.headway.core.designSystem.component.FreudText
+import dev.kigya.headway.core.designSystem.util.FreudScreenByWidth
+import dev.kigya.headway.core.designSystem.util.FreudTextValue
+import dev.kigya.headway.feature.learnQuestions.internal.ui.theme.LearnQuestionsTheme
+import dev.kigya.headway.feature.learnQuestions.internal.ui.theme.LearnQuestionsTheme.learnActionContainer
+import dev.kigya.headway.feature.learnQuestions.internal.ui.theme.LearnQuestionsTheme.learnActionContent
+import dev.kigya.headway.feature.learnQuestions.internal.ui.theme.LearnQuestionsTheme.learnBackground
+import dev.kigya.headway.feature.learnQuestions.internal.ui.theme.LearnQuestionsTheme.learnPrimaryText
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+internal fun LearnQuestionsScreen() {
+    val viewModel = koinViewModel<LearnQuestionsViewModel>()
+    val state = viewModel.uiState.collectAsStateWithLifecycle()
+
+    LearnQuestionsScreenContent(
+        state = state,
+        onGuestSignOut = viewModel::onGuestSignOut,
+        onRetryLoad = viewModel::onRetryLoad,
+    )
+}
+
+@Composable
+private fun LearnQuestionsScreenContent(
+    state: State<LearnQuestionsStore.State>,
+    onGuestSignOut: () -> Unit,
+    onRetryLoad: () -> Unit,
+) {
+    val content: @Composable BoxScope.() -> Unit = {
+        FreudFallback(
+            isError = state.value.errorMessage != null,
+            onRetry = onRetryLoad,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(LearnQuestionsTheme.colorScheme.learnBackground.value)
+                    .padding(LearnQuestionsTheme.dimension.dp24.value),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                FreudText(
+                    value = FreudTextValue.text(state.value.title),
+                    color = LearnQuestionsTheme.colorScheme.learnPrimaryText,
+                    typography = LearnQuestionsTheme.typography.headingSmExtraBold,
+                )
+                FreudSpacer(size = LearnQuestionsTheme.dimension.dp12)
+                FreudText(
+                    value = FreudTextValue.text(state.value.detail),
+                    color = LearnQuestionsTheme.colorScheme.learnPrimaryText,
+                    typography = LearnQuestionsTheme.typography.paragraphLg,
+                )
+                FreudSpacer(size = LearnQuestionsTheme.dimension.dp24)
+                FreudHorizontalButton(
+                    text = FreudTextValue.text("Guest sign out"),
+                    onClick = onGuestSignOut,
+                    containerColor = LearnQuestionsTheme.colorScheme.learnActionContainer,
+                    contentColor = LearnQuestionsTheme.colorScheme.learnActionContent,
+                    size = FreudHorizontalButtonSize.LARGE,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+
+    FreudScreenByWidth(
+        narrow = content,
+        wide = content,
+    )
+}

--- a/client/feature/learn-questions/internal/src/commonMain/kotlin/dev/kigya/headway/feature/learnQuestions/internal/ui/screen/LearnQuestionsStore.kt
+++ b/client/feature/learn-questions/internal/src/commonMain/kotlin/dev/kigya/headway/feature/learnQuestions/internal/ui/screen/LearnQuestionsStore.kt
@@ -1,0 +1,118 @@
+package dev.kigya.headway.feature.learnQuestions.internal.ui.screen
+
+import androidx.compose.runtime.Immutable
+import com.arkivanov.mvikotlin.core.store.Reducer
+import com.arkivanov.mvikotlin.core.store.Store
+import com.arkivanov.mvikotlin.core.store.StoreFactory
+import com.arkivanov.mvikotlin.extensions.coroutines.coroutineBootstrapper
+import com.arkivanov.mvikotlin.extensions.coroutines.coroutineExecutorFactory
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.usecase.LoadGuestLearningOverviewUseCase
+import dev.kigya.headway.core.session.domain.usecase.LogoutGuestUseCase
+import dev.kigya.headway.feature.auth.api.AuthScreenKey
+import dev.kigya.headway.feature.learnQuestions.internal.ui.screen.LearnQuestionsStore.Intent
+import dev.kigya.headway.feature.learnQuestions.internal.ui.screen.LearnQuestionsStore.Label
+import dev.kigya.headway.feature.learnQuestions.internal.ui.screen.LearnQuestionsStore.State
+import dev.kigya.headway.navigation.api.navigator.NavigationIntent
+import dev.kigya.headway.navigation.api.navigator.NavigatorContract
+import dev.kigya.headway.navigation.api.navigator.asNavigationAsyncRunner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+interface LearnQuestionsStore : Store<Intent, State, Label> {
+    sealed interface Intent {
+        data object GuestSignOut : Intent
+        data object RetryLoad : Intent
+    }
+
+    sealed interface Label
+
+    @Immutable
+    data class State(
+        val title: String = "",
+        val detail: String = "",
+        val errorMessage: String? = null,
+    )
+}
+
+class LearnQuestionsStoreFactory(
+    private val storeFactory: StoreFactory,
+    private val navigator: NavigatorContract,
+    private val loadGuestLearningOverview: LoadGuestLearningOverviewUseCase,
+    private val logoutGuest: LogoutGuestUseCase,
+) {
+    fun create(executorCoroutineScope: CoroutineScope): LearnQuestionsStore = object :
+        LearnQuestionsStore,
+        Store<Intent, State, Label>
+        by storeFactory.create<Intent, Action, Message, State, Label>(
+            name = this::class.simpleName,
+            initialState = State(),
+            bootstrapper = coroutineBootstrapper {
+                dispatch(Action.LoadOverview)
+            },
+            executorFactory = coroutineExecutorFactory(executorCoroutineScope.coroutineContext) {
+                onAction<Action.LoadOverview> {
+                    launch {
+                        when (val overview = loadGuestLearningOverview()) {
+                            is Outcome.Success -> dispatch(
+                                Message.ContentLoaded(
+                                    title = overview.value.headline,
+                                    detail = overview.value.detailLine,
+                                ),
+                            )
+
+                            is Outcome.Failure -> dispatch(Message.LoadFailed)
+                        }
+                    }
+                }
+                onIntent<Intent.RetryLoad> {
+                    dispatch(Message.ClearError)
+                    launch {
+                        when (val overview = loadGuestLearningOverview()) {
+                            is Outcome.Success -> dispatch(
+                                Message.ContentLoaded(
+                                    title = overview.value.headline,
+                                    detail = overview.value.detailLine,
+                                ),
+                            )
+
+                            is Outcome.Failure -> dispatch(Message.LoadFailed)
+                        }
+                    }
+                }
+                onIntent<Intent.GuestSignOut> {
+                    launch {
+                        logoutGuest()
+                        navigator.navigate(
+                            NavigationIntent.ReplaceTopBy(
+                                screenNavigationKey = AuthScreenKey,
+                                asyncRunner = { executorCoroutineScope.asNavigationAsyncRunner() },
+                            ),
+                        )
+                    }
+                }
+            },
+            reducer = Reducer { message ->
+                when (message) {
+                    is Message.ContentLoaded -> copy(
+                        title = message.title,
+                        detail = message.detail,
+                        errorMessage = null,
+                    )
+
+                    Message.LoadFailed -> copy(errorMessage = "Could not load learning content.")
+                    Message.ClearError -> copy(errorMessage = null)
+                }
+            },
+        ) {}
+
+    private sealed interface Action {
+        data object LoadOverview : Action
+    }
+
+    private sealed interface Message {
+        data class ContentLoaded(val title: String, val detail: String) : Message
+        data object LoadFailed : Message
+        data object ClearError : Message
+    }
+}

--- a/client/feature/learn-questions/internal/src/commonMain/kotlin/dev/kigya/headway/feature/learnQuestions/internal/ui/screen/LearnQuestionsViewModel.kt
+++ b/client/feature/learn-questions/internal/src/commonMain/kotlin/dev/kigya/headway/feature/learnQuestions/internal/ui/screen/LearnQuestionsViewModel.kt
@@ -1,0 +1,35 @@
+package dev.kigya.headway.feature.learnQuestions.internal.ui.screen
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.arkivanov.mvikotlin.core.store.StoreFactory
+import com.arkivanov.mvikotlin.extensions.coroutines.stateFlow
+import dev.kigya.headway.core.session.domain.usecase.LoadGuestLearningOverviewUseCase
+import dev.kigya.headway.core.session.domain.usecase.LogoutGuestUseCase
+import dev.kigya.headway.navigation.api.navigator.NavigatorContract
+import kotlinx.coroutines.flow.StateFlow
+
+class LearnQuestionsViewModel(
+    storeFactory: StoreFactory,
+    navigator: NavigatorContract,
+    loadGuestLearningOverview: LoadGuestLearningOverviewUseCase,
+    logoutGuest: LogoutGuestUseCase,
+) : ViewModel() {
+
+    private val store: LearnQuestionsStore = LearnQuestionsStoreFactory(
+        storeFactory = storeFactory,
+        navigator = navigator,
+        loadGuestLearningOverview = loadGuestLearningOverview,
+        logoutGuest = logoutGuest,
+    ).create(viewModelScope)
+
+    val uiState: StateFlow<LearnQuestionsStore.State> = store.stateFlow(viewModelScope)
+
+    fun onGuestSignOut() {
+        store.accept(LearnQuestionsStore.Intent.GuestSignOut)
+    }
+
+    fun onRetryLoad() {
+        store.accept(LearnQuestionsStore.Intent.RetryLoad)
+    }
+}

--- a/client/feature/learn-questions/internal/src/commonMain/kotlin/dev/kigya/headway/feature/learnQuestions/internal/ui/theme/LearnQuestionsTheme.kt
+++ b/client/feature/learn-questions/internal/src/commonMain/kotlin/dev/kigya/headway/feature/learnQuestions/internal/ui/theme/LearnQuestionsTheme.kt
@@ -1,0 +1,37 @@
+package dev.kigya.headway.feature.learnQuestions.internal.ui.theme
+
+import androidx.compose.runtime.Composable
+import dev.kigya.headway.core.designSystem.theme.FreudTheme
+import dev.kigya.headway.core.designSystem.theme.color.FreudColorScheme
+import dev.kigya.headway.core.designSystem.theme.color.FreudDynamicColor
+import dev.kigya.headway.core.designSystem.theme.color.provides
+
+internal object LearnQuestionsTheme : FreudTheme() {
+    val FreudColorScheme.learnBackground
+        @Composable
+        get() = this provides FreudDynamicColor(
+            light = super.color.brown10,
+            dark = super.color.brown100,
+        )
+
+    val FreudColorScheme.learnPrimaryText
+        @Composable
+        get() = this provides FreudDynamicColor(
+            light = super.color.brown90,
+            dark = super.color.brown40,
+        )
+
+    val FreudColorScheme.learnActionContainer
+        @Composable
+        get() = this provides FreudDynamicColor(
+            light = super.color.brown80,
+            dark = super.color.brown40,
+        )
+
+    val FreudColorScheme.learnActionContent
+        @Composable
+        get() = this provides FreudDynamicColor(
+            light = super.color.brown10,
+            dark = super.color.brown100,
+        )
+}

--- a/client/feature/splash/api/build.gradle.kts
+++ b/client/feature/splash/api/build.gradle.kts
@@ -10,6 +10,6 @@ plugins {
 
 commonMainDependencies {
     projects {
-        implementation(navigation.api)
+        implementation(navigation.navigationApi)
     }
 }

--- a/client/feature/splash/di/build.gradle.kts
+++ b/client/feature/splash/di/build.gradle.kts
@@ -10,8 +10,9 @@ plugins {
 
 commonMainDependencies {
     projects {
-        implementation(feature.splash.api)
-        implementation(feature.splash.internal)
-        implementation(navigation.api)
+        implementation(core.sessionInternal)
+        implementation(feature.splashApi)
+        implementation(feature.splashInternal)
+        implementation(navigation.navigationApi)
     }
 }

--- a/client/feature/splash/internal/build.gradle.kts
+++ b/client/feature/splash/internal/build.gradle.kts
@@ -10,11 +10,20 @@ plugins {
     alias(libs.plugins.convention.component.mvi)
 }
 
+compose {
+    resources {
+        packageOfResClass = "headway.feature.splash.internal.generated.resources"
+    }
+}
+
 commonMainDependencies {
     projects {
-        implementation(navigation.api)
+        implementation(core.sessionInternal)
+        implementation(navigation.navigationApi)
         implementation(core.designSystem)
-        implementation(feature.splash.api)
-        implementation(feature.auth.api)
+        implementation(feature.splashApi)
+        implementation(feature.authApi)
+        implementation(feature.homeApi)
+        implementation(feature.learnQuestionsApi)
     }
 }

--- a/client/feature/splash/internal/src/commonMain/kotlin/dev/kigya/headway/feature/splash/internal/ui/screen/SplashStore.kt
+++ b/client/feature/splash/internal/src/commonMain/kotlin/dev/kigya/headway/feature/splash/internal/ui/screen/SplashStore.kt
@@ -6,7 +6,12 @@ import com.arkivanov.mvikotlin.core.store.Store
 import com.arkivanov.mvikotlin.core.store.StoreFactory
 import com.arkivanov.mvikotlin.extensions.coroutines.coroutineBootstrapper
 import com.arkivanov.mvikotlin.extensions.coroutines.coroutineExecutorFactory
+import dev.kigya.headway.core.outcome.getOrNull
+import dev.kigya.headway.core.session.domain.usecase.ResolveLaunchDestinationUseCase
+import dev.kigya.headway.core.session.model.LaunchDestination
 import dev.kigya.headway.feature.auth.api.AuthScreenKey
+import dev.kigya.headway.feature.home.api.HomeScreenKey
+import dev.kigya.headway.feature.learnQuestions.api.LearnQuestionsScreenKey
 import dev.kigya.headway.feature.splash.internal.ui.screen.SplashStore.Intent
 import dev.kigya.headway.feature.splash.internal.ui.screen.SplashStore.Label
 import dev.kigya.headway.feature.splash.internal.ui.screen.SplashStore.State
@@ -30,6 +35,7 @@ interface SplashStore : Store<Intent, State, Label> {
 class SplashStoreFactory(
     private val storeFactory: StoreFactory,
     private val navigator: NavigatorContract,
+    private val resolveLaunchDestination: ResolveLaunchDestinationUseCase,
 ) {
     fun create(executorCoroutineScope: CoroutineScope): SplashStore = object :
         SplashStore,
@@ -41,22 +47,27 @@ class SplashStoreFactory(
                 launch {
                     delay(showTextDelay)
                     dispatch(Action.ShowText)
+                    delay(afterTextDelay)
+                    val destination = resolveLaunchDestination().getOrNull()
+                        ?: LaunchDestination.Auth
+                    executorCoroutineScope.launch {
+                        val key = when (destination) {
+                            LaunchDestination.Auth -> AuthScreenKey
+                            LaunchDestination.Home -> HomeScreenKey
+                            LaunchDestination.LearnQuestions -> LearnQuestionsScreenKey
+                        }
+                        navigator.navigate(
+                            NavigationIntent.ReplaceTopBy(
+                                screenNavigationKey = key,
+                                asyncRunner = { executorCoroutineScope.asNavigationAsyncRunner() },
+                            ),
+                        )
+                    }
                 }
             },
             executorFactory = coroutineExecutorFactory(executorCoroutineScope.coroutineContext) {
                 onAction<Action.ShowText> {
-                    launch {
-                        dispatch(Message.ShowText)
-                        delay(afterTextDelay)
-                        executorCoroutineScope.launch {
-                            navigator.navigate(
-                                NavigationIntent.ReplaceTopBy(
-                                    screenNavigationKey = AuthScreenKey,
-                                    asyncRunner = { executorCoroutineScope.asNavigationAsyncRunner() },
-                                ),
-                            )
-                        }
-                    }
+                    dispatch(Message.ShowText)
                 }
             },
             reducer = Reducer { message ->
@@ -67,11 +78,11 @@ class SplashStoreFactory(
         ) {}
 
     private sealed interface Action {
-        object ShowText : Action
+        data object ShowText : Action
     }
 
     private sealed interface Message {
-        object ShowText : Message
+        data object ShowText : Message
     }
 
     private companion object {

--- a/client/feature/splash/internal/src/commonMain/kotlin/dev/kigya/headway/feature/splash/internal/ui/screen/SplashViewModel.kt
+++ b/client/feature/splash/internal/src/commonMain/kotlin/dev/kigya/headway/feature/splash/internal/ui/screen/SplashViewModel.kt
@@ -4,16 +4,19 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.arkivanov.mvikotlin.core.store.StoreFactory
 import com.arkivanov.mvikotlin.extensions.coroutines.stateFlow
+import dev.kigya.headway.core.session.domain.usecase.ResolveLaunchDestinationUseCase
 import dev.kigya.headway.navigation.api.navigator.NavigatorContract
 import kotlinx.coroutines.flow.StateFlow
 
 class SplashViewModel(
     storeFactory: StoreFactory,
     navigator: NavigatorContract,
+    resolveLaunchDestination: ResolveLaunchDestinationUseCase,
 ) : ViewModel() {
     private val store: SplashStore = SplashStoreFactory(
         storeFactory = storeFactory,
         navigator = navigator,
+        resolveLaunchDestination = resolveLaunchDestination,
     ).create(viewModelScope)
 
     val uiState: StateFlow<SplashStore.State> = store.stateFlow(viewModelScope)

--- a/client/gradle/libs.versions.toml
+++ b/client/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ coroutines = { require = "1.10.2" }
 kotlinxSerialization = { require = "1.10.0" }
 kotlinxDatetime = { prefer = "0.7.1" }
 kotlinxCollectionsImmutable = { require = "0.4.0" }
+kotlinxBrowser = { require = "0.3" }
 
 # Compose Multiplatform
 composeMultiplatform = { require = "1.10.3" }
@@ -44,6 +45,13 @@ connectivity = { require = "2.4.1" }
 dataStore = { require = "1.2.1" }
 room = { strictly = "2.8.4" }
 sqlite = { strictly = "2.6.2" }
+securityCrypto = { require = "1.1.0-alpha06" }
+
+# GraphQL (client gateway)
+apollo = "4.3.1"
+
+# Google Sign-In (Android)
+playServicesAuth = { require = "21.3.0" }
 
 # Authentication
 kmpAuth = { require = "2.3.1" }
@@ -69,8 +77,10 @@ coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", 
 serializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 kotlinxDatetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 immutableCollections = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
+kotlinx-browser-wasm-js = { module = "org.jetbrains.kotlinx:kotlinx-browser-wasm-js", version.ref = "kotlinxBrowser" }
 
 # --- Compose ---
+activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "composeActivity" }
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "composeActivity" }
 compose-adaptive = { module = "org.jetbrains.compose.material3.adaptive:adaptive", version.ref = "composeMaterial3Adaptive" }
 compose-windowSizeClass = { module = "org.jetbrains.compose.material3:material3-window-size-class", version.ref = "composeWindowSizeClass" }
@@ -125,6 +135,10 @@ google-api-client = { module = "com.google.api-client:google-api-client", versio
 dataStore-core = { module = "androidx.datastore:datastore-core", version.ref = "dataStore" }
 dataStore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "dataStore" }
 dataStore-preferencesCore = { module = "androidx.datastore:datastore-preferences-core", version.ref = "dataStore" }
+security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }
+apollo-api = { module = "com.apollographql.apollo:apollo-api", version.ref = "apollo" }
+apollo-runtime = { module = "com.apollographql.apollo:apollo-runtime", version.ref = "apollo" }
+play-services-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
@@ -179,6 +193,7 @@ googleServices = { id = "com.google.gms.google-services", version.ref = "googleS
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 room = { id = "androidx.room", version.ref = "room" }
 buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig" }
+apollo = { id = "com.apollographql.apollo", version.ref = "apollo" }
 
 # Convention Plugins Configuration
 convention-base-androidApplication = "base.androidApplication:1.0"

--- a/client/navigation/di/build.gradle.kts
+++ b/client/navigation/di/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 commonMainDependencies {
     projects {
-        implementation(navigation.api)
-        implementation(navigation.internal)
+        implementation(navigation.navigationApi)
+        implementation(navigation.navigationInternal)
     }
 }

--- a/client/navigation/internal/build.gradle.kts
+++ b/client/navigation/internal/build.gradle.kts
@@ -11,6 +11,6 @@ plugins {
 
 commonMainDependencies {
     projects {
-        implementation(navigation.api)
+        implementation(navigation.navigationApi)
     }
 }

--- a/client/navigation/internal/src/commonMain/kotlin/dev/kigya/headway/navigation/internal/HeadwayNavigator.kt
+++ b/client/navigation/internal/src/commonMain/kotlin/dev/kigya/headway/navigation/internal/HeadwayNavigator.kt
@@ -31,8 +31,9 @@ class HeadwayNavigator(
                 with(this as NavigatorScope) {
                     val runner = intent.asyncRunner()
                     runner {
-                        if (this@HeadwayNavigator._backStack.lastOrNull() != intent.asyncRunner) {
-                            this@HeadwayNavigator._backStack.add(intent.screenNavigationKey)
+                        val targetKey = intent.screenNavigationKey
+                        if (this@HeadwayNavigator._backStack.lastOrNull() != targetKey) {
+                            this@HeadwayNavigator._backStack.add(targetKey)
                         }
                         delay(REPLACE_TOP_DELAY)
                         if (this@HeadwayNavigator._backStack.size > 1) {

--- a/client/settings.gradle.kts
+++ b/client/settings.gradle.kts
@@ -44,22 +44,65 @@ include(
 
     ":shared",
 
-    ":feature:splash:api",
-    ":feature:splash:internal",
-    ":feature:splash:di",
+    "feature:splash-api",
+    "feature:splash-internal",
+    "feature:splash-di",
 
-    ":feature:auth:api",
-    ":feature:auth:internal",
-    ":feature:auth:di",
+    "feature:auth-api",
+    "feature:auth-internal",
+    "feature:auth-di",
 
-    ":navigation:api",
-    ":navigation:internal",
-    ":navigation:di",
+    "navigation:navigation-api",
+    "navigation:navigation-internal",
+    "navigation:navigation-di",
 
-    ":di:api",
-    ":di:modules",
+    "di:di-api",
+    "di:di-modules",
 
     "core:annotation",
+    "core:network-api",
+    "core:apollo",
     "core:design-system",
     "core:outcome",
+    "core:storage-api",
+    "core:storage-secure",
+    "core:session-api",
+    "core:session-internal",
+
+    "feature:home-api",
+    "feature:home-internal",
+    "feature:home-di",
+
+    "feature:learn-questions-api",
+    "feature:learn-questions-internal",
+    "feature:learn-questions-di",
 )
+
+project(":core:network-api").projectDir = file("core/network/api")
+project(":core:storage-api").projectDir = file("core/storage/api")
+project(":core:storage-secure").projectDir = file("core/storage/secure")
+project(":core:session-api").projectDir = file("core/session/api")
+project(":core:session-internal").projectDir = file("core/session/internal")
+
+project(":feature:splash-api").projectDir = file("feature/splash/api")
+project(":feature:splash-internal").projectDir = file("feature/splash/internal")
+project(":feature:splash-di").projectDir = file("feature/splash/di")
+
+project(":feature:auth-api").projectDir = file("feature/auth/api")
+project(":feature:auth-internal").projectDir = file("feature/auth/internal")
+project(":feature:auth-di").projectDir = file("feature/auth/di")
+
+project(":feature:home-api").projectDir = file("feature/home/api")
+project(":feature:home-internal").projectDir = file("feature/home/internal")
+project(":feature:home-di").projectDir = file("feature/home/di")
+
+project(":feature:learn-questions-api").projectDir = file("feature/learn-questions/api")
+project(":feature:learn-questions-internal").projectDir = file("feature/learn-questions/internal")
+project(":feature:learn-questions-di").projectDir = file("feature/learn-questions/di")
+
+project(":navigation:navigation-api").projectDir = file("navigation/api")
+project(":navigation:navigation-internal").projectDir = file("navigation/internal")
+project(":navigation:navigation-di").projectDir = file("navigation/di")
+
+project(":di:di-api").projectDir = file("di/api")
+project(":di:di-modules").projectDir = file("di/modules")

--- a/client/shared/build.gradle.kts
+++ b/client/shared/build.gradle.kts
@@ -1,4 +1,5 @@
 import extension.commonMainDependencies
+import extension.iosMainDependencies
 
 plugins {
     alias(libs.plugins.convention.base.sharedLibrary)
@@ -19,10 +20,18 @@ kotlin {
 
 commonMainDependencies {
     projects {
-        implementation(di.modules)
-        implementation(navigation.api)
+        implementation(di.diModules)
+        implementation(navigation.navigationApi)
         implementation(core.designSystem)
-        implementation(feature.splash.api)
-        implementation(feature.auth.api)
+        implementation(feature.splashApi)
+        implementation(feature.authApi)
+        implementation(feature.homeApi)
+        implementation(feature.learnQuestionsApi)
+    }
+}
+
+iosMainDependencies {
+    projects {
+        implementation(core.sessionInternal)
     }
 }

--- a/client/shared/src/androidMain/kotlin/dev/kigya/headway/HeadwayKoinHost.android.kt
+++ b/client/shared/src/androidMain/kotlin/dev/kigya/headway/HeadwayKoinHost.android.kt
@@ -1,0 +1,8 @@
+package dev.kigya.headway
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun HeadwayKoinHost(content: @Composable () -> Unit) {
+    content()
+}

--- a/client/shared/src/commonMain/kotlin/dev/kigya/headway/App.kt
+++ b/client/shared/src/commonMain/kotlin/dev/kigya/headway/App.kt
@@ -6,30 +6,32 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import dev.kigya.headway.core.designSystem.theme.FreudTheme
-import dev.kigya.headway.di.api.appModules
 import dev.kigya.headway.feature.auth.api.AuthNoAccessScreenKey
 import dev.kigya.headway.feature.auth.api.AuthNoAccessScreenRouteHolderContract
 import dev.kigya.headway.feature.auth.api.AuthScreenKey
 import dev.kigya.headway.feature.auth.api.AuthScreenRouteHolderContract
+import dev.kigya.headway.feature.home.api.HomeScreenKey
+import dev.kigya.headway.feature.home.api.HomeScreenRouteHolderContract
+import dev.kigya.headway.feature.learnQuestions.api.LearnQuestionsScreenKey
+import dev.kigya.headway.feature.learnQuestions.api.LearnQuestionsScreenRouteHolderContract
 import dev.kigya.headway.feature.splash.api.SplashScreenKey
 import dev.kigya.headway.feature.splash.api.SplashScreenRouteHolderContract
 import dev.kigya.headway.navigation.api.navigator.NavigationIntent
 import dev.kigya.headway.navigation.api.navigator.NavigatorContract
-import org.koin.compose.KoinMultiplatformApplication
 import org.koin.compose.currentKoinScope
 import org.koin.compose.scope.rememberKoinScope
-import org.koin.dsl.KoinConfiguration
 
 @Composable
 fun App() {
-    KoinMultiplatformApplication(
-        config = KoinConfiguration { modules(appModules) },
-    ) {
+    HeadwayKoinHost {
         FreudTheme {
             AppNavigationHost()
         }
     }
 }
+
+@Composable
+expect fun HeadwayKoinHost(content: @Composable () -> Unit)
 
 @Composable
 private fun AppNavigationHost() {
@@ -39,6 +41,8 @@ private fun AppNavigationHost() {
     val splashRoute = koinScope.get<SplashScreenRouteHolderContract>()
     val authRoute = koinScope.get<AuthScreenRouteHolderContract>()
     val authNoAccessRoute = koinScope.get<AuthNoAccessScreenRouteHolderContract>()
+    val homeRoute = koinScope.get<HomeScreenRouteHolderContract>()
+    val learnQuestionsRoute = koinScope.get<LearnQuestionsScreenRouteHolderContract>()
 
     NavDisplay(
         backStack = navigator.backStack,
@@ -51,6 +55,8 @@ private fun AppNavigationHost() {
             entry<SplashScreenKey> { splashRoute.content() }
             entry<AuthScreenKey> { authRoute.content() }
             entry<AuthNoAccessScreenKey> { authNoAccessRoute.content() }
+            entry<HomeScreenKey> { homeRoute.content() }
+            entry<LearnQuestionsScreenKey> { learnQuestionsRoute.content() }
         },
     )
 }

--- a/client/shared/src/desktopMain/kotlin/dev/kigya/headway/HeadwayKoinHost.desktop.kt
+++ b/client/shared/src/desktopMain/kotlin/dev/kigya/headway/HeadwayKoinHost.desktop.kt
@@ -1,0 +1,14 @@
+package dev.kigya.headway
+
+import androidx.compose.runtime.Composable
+import dev.kigya.headway.di.api.appModules
+import org.koin.compose.KoinApplication
+import org.koin.dsl.KoinConfiguration
+
+@Composable
+actual fun HeadwayKoinHost(content: @Composable () -> Unit) {
+    KoinApplication(
+        configuration = KoinConfiguration { modules(appModules) },
+        content = content,
+    )
+}

--- a/client/shared/src/iosMain/kotlin/dev/kigya/headway/HeadwayKoinHost.ios.kt
+++ b/client/shared/src/iosMain/kotlin/dev/kigya/headway/HeadwayKoinHost.ios.kt
@@ -1,0 +1,22 @@
+package dev.kigya.headway
+
+import androidx.compose.runtime.Composable
+import dev.kigya.headway.core.session.domain.contract.GoogleIdTokenAcquisitionContract
+import dev.kigya.headway.di.api.appModules
+import org.koin.compose.KoinApplication
+import org.koin.dsl.KoinConfiguration
+import org.koin.dsl.module
+
+private val headwayIosGoogleKoinModule = module {
+    single<GoogleIdTokenAcquisitionContract> { IosGoogleIdTokenAcquisition() }
+}
+
+@Composable
+actual fun HeadwayKoinHost(content: @Composable () -> Unit) {
+    KoinApplication(
+        configuration = KoinConfiguration {
+            modules(appModules + headwayIosGoogleKoinModule)
+        },
+        content = content,
+    )
+}

--- a/client/shared/src/iosMain/kotlin/dev/kigya/headway/IosGoogleSignInBridge.kt
+++ b/client/shared/src/iosMain/kotlin/dev/kigya/headway/IosGoogleSignInBridge.kt
@@ -1,0 +1,59 @@
+package dev.kigya.headway
+
+import dev.kigya.headway.core.outcome.Outcome
+import dev.kigya.headway.core.session.domain.contract.GoogleIdTokenAcquisitionContract
+import dev.kigya.headway.core.session.domain.error.SessionDomainError
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.coroutines.resume
+
+private var headwayIosGoogleSignInRunner: (() -> Unit)? = null
+
+private var headwayIosGoogleAwaiting: CancellableContinuation<Outcome<SessionDomainError, String>>? = null
+
+fun headwayIosRegisterGoogleSignInRunner(run: () -> Unit) {
+    headwayIosGoogleSignInRunner = run
+}
+
+fun headwayIosOnGoogleSignInSuccess(idToken: String) {
+    val continuation = headwayIosGoogleAwaiting
+    headwayIosGoogleAwaiting = null
+    continuation?.resume(Outcome.success(idToken))
+}
+
+fun headwayIosOnGoogleSignInUserCancelled() {
+    val continuation = headwayIosGoogleAwaiting
+    headwayIosGoogleAwaiting = null
+    continuation?.resume(Outcome.failure(SessionDomainError.GoogleSignInCancelled))
+}
+
+fun headwayIosOnGoogleSignInUnavailable() {
+    val continuation = headwayIosGoogleAwaiting
+    headwayIosGoogleAwaiting = null
+    continuation?.resume(Outcome.failure(SessionDomainError.GoogleSignInUnavailable))
+}
+
+internal suspend fun headwayIosSuspendForGoogleIdToken(): Outcome<SessionDomainError, String> =
+    suspendCancellableCoroutine { continuation ->
+        headwayIosGoogleAwaiting?.cancel(CancellationException("replaced"))
+        headwayIosGoogleAwaiting = continuation
+        continuation.invokeOnCancellation {
+            if (headwayIosGoogleAwaiting === continuation) {
+                headwayIosGoogleAwaiting = null
+            }
+        }
+        val runner = headwayIosGoogleSignInRunner
+        if (runner == null) {
+            headwayIosGoogleAwaiting = null
+            continuation.resume(Outcome.failure(SessionDomainError.GoogleSignInUnavailable))
+        } else {
+            runner()
+        }
+    }
+
+internal class IosGoogleIdTokenAcquisition : GoogleIdTokenAcquisitionContract {
+
+    override suspend fun obtainIdToken(): Outcome<SessionDomainError, String> =
+        headwayIosSuspendForGoogleIdToken()
+}

--- a/client/shared/src/webMain/kotlin/dev/kigya/headway/HeadwayKoinHost.web.kt
+++ b/client/shared/src/webMain/kotlin/dev/kigya/headway/HeadwayKoinHost.web.kt
@@ -1,0 +1,14 @@
+package dev.kigya.headway
+
+import androidx.compose.runtime.Composable
+import dev.kigya.headway.di.api.appModules
+import org.koin.compose.KoinApplication
+import org.koin.dsl.KoinConfiguration
+
+@Composable
+actual fun HeadwayKoinHost(content: @Composable () -> Unit) {
+    KoinApplication(
+        configuration = KoinConfiguration { modules(appModules) },
+        content = content,
+    )
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,398 @@
+projects:
+  - name: headway-backend
+    environments:
+      - name: dev
+        envVarGroups:
+          - name: headway-dev-shared
+            envVars:
+              - key: ENV
+                value: dev
+        services:
+          - name: kigya-headway-dev-gateway
+            type: web
+            runtime: docker
+            plan: free
+            region: frankfurt
+            branch: client-headway/86-client-auth-flow
+            autoDeployTrigger: off
+            rootDir: server
+            dockerfilePath: docker/render/Gateway.Dockerfile
+            dockerContext: .
+            healthCheckPath: /healthz
+            envVars:
+              - fromGroup: headway-dev-shared
+              - key: PORT
+                value: "8080"
+              - key: GATEWAY_SERVICE_HOST
+                value: "0.0.0.0"
+              - key: GATEWAY_SERVICE_PORT
+                value: "8080"
+              - key: AUTH_SERVICE_HOST
+                fromService:
+                  name: kigya-headway-dev-auth
+                  type: pserv
+                  property: host
+              - key: AUTH_SERVICE_PORT
+                fromService:
+                  name: kigya-headway-dev-auth
+                  type: pserv
+                  property: port
+              - key: DATABASE_SERVICE_HOST
+                fromService:
+                  name: kigya-headway-dev-database
+                  type: pserv
+                  property: host
+              - key: DATABASE_SERVICE_PORT
+                fromService:
+                  name: kigya-headway-dev-database
+                  type: pserv
+                  property: port
+              - key: HOME_SERVICE_HOST
+                fromService:
+                  name: kigya-headway-dev-home
+                  type: pserv
+                  property: host
+              - key: HOME_SERVICE_PORT
+                fromService:
+                  name: kigya-headway-dev-home
+                  type: pserv
+                  property: port
+
+          - name: kigya-headway-dev-auth
+            type: pserv
+            runtime: docker
+            plan: starter
+            region: frankfurt
+            branch: client-headway/86-client-auth-flow
+            autoDeployTrigger: off
+            rootDir: server
+            dockerfilePath: docker/render/Auth.Dockerfile
+            dockerContext: .
+            envVars:
+              - fromGroup: headway-dev-shared
+              - key: PORT
+                value: "8081"
+              - key: AUTH_SERVICE_SELF_HOST
+                value: "0.0.0.0"
+              - key: AUTH_SERVICE_PORT
+                value: "8081"
+              - key: DATABASE_SERVICE_HOST
+                fromService:
+                  name: kigya-headway-dev-database
+                  type: pserv
+                  property: host
+              - key: DATABASE_SERVICE_PORT
+                fromService:
+                  name: kigya-headway-dev-database
+                  type: pserv
+                  property: port
+              - key: JWT_ISSUER
+                value: headway-auth
+              - key: JWT_AUDIENCE
+                value: headway-gateway
+              - key: JWT_ACCESS_SECRET
+                sync: false
+              - key: JWT_REFRESH_SECRET
+                sync: false
+              - key: JWT_ACCESS_TTL_SEC
+                value: "300"
+              - key: JWT_GUEST_SECRET
+                sync: false
+              - key: JWT_GUEST_TTL_SEC
+                value: "86400"
+              - key: GOOGLE_TOKEN_AUDIENCE
+                value: 658272377808-alf63nc9km4tjgv0dr6lltfqfo1jshqb.apps.googleusercontent.com
+
+          - name: kigya-headway-dev-database
+            type: pserv
+            runtime: docker
+            plan: starter
+            region: frankfurt
+            branch: client-headway/86-client-auth-flow
+            autoDeployTrigger: off
+            rootDir: server
+            dockerfilePath: docker/render/Database.Dockerfile
+            dockerContext: .
+            envVars:
+              - fromGroup: headway-dev-shared
+              - key: PORT
+                value: "8082"
+              - key: DATABASE_SELF_SERVICE_HOST
+                value: "0.0.0.0"
+              - key: DATABASE_SERVICE_PORT
+                value: "8082"
+              - key: DATABASE_HOST_URL
+                value: aws-1-eu-north-1.pooler.supabase.com
+              - key: DATABASE_PORT
+                value: "5432"
+              - key: DATABASE_NAME
+                value: postgres
+              - key: DATABASE_USER
+                value: postgres.ymqpiogjzymkkwzutqds
+              - key: DATABASE_PASSWORD
+                sync: false
+              - key: DATABASE_SSL_MODE
+                value: disable
+              - key: DATABASE_POOL_SIZE
+                value: "3"
+
+          - name: kigya-headway-dev-home
+            type: pserv
+            runtime: docker
+            plan: starter
+            region: frankfurt
+            branch: client-headway/86-client-auth-flow
+            autoDeployTrigger: off
+            rootDir: server
+            dockerfilePath: docker/render/Home.Dockerfile
+            dockerContext: .
+            envVars:
+              - fromGroup: headway-dev-shared
+              - key: PORT
+                value: "8084"
+              - key: HOME_SERVICE_SELF_HOST
+                value: "0.0.0.0"
+              - key: HOME_SERVICE_PORT
+                value: "8084"
+              - key: HOME_ICONS_PUBLIC_BASE_URL
+                value: https://ymqpiogjzymkkwzutqds.supabase.co/storage/v1/object/public/icons
+
+          - name: kigya-headway-dev-admin
+            type: web
+            runtime: docker
+            plan: free
+            region: frankfurt
+            branch: client-headway/86-client-auth-flow
+            autoDeployTrigger: off
+            rootDir: server
+            dockerfilePath: docker/render/Admin.Dockerfile
+            dockerContext: .
+            healthCheckPath: /internal/v1/admin/healthz
+            envVars:
+              - fromGroup: headway-dev-shared
+              - key: PORT
+                value: "8083"
+              - key: ADMIN_SERVICE_HOST
+                value: "0.0.0.0"
+              - key: ADMIN_SERVICE_PORT
+                value: "8083"
+              - key: DATABASE_SERVICE_HOST
+                fromService:
+                  name: kigya-headway-dev-database
+                  type: pserv
+                  property: host
+              - key: DATABASE_SERVICE_PORT
+                fromService:
+                  name: kigya-headway-dev-database
+                  type: pserv
+                  property: port
+              - key: HEADWAY_GITHUB_OAUTH_CLIENT_ID
+                value: Ov23lilAEAUJM7Vn9CpX
+              - key: HEADWAY_GITHUB_OAUTH_CLIENT_SECRET
+                sync: false
+              - key: HEADWAY_REPO_OWNER
+                value: kigya
+              - key: HEADWAY_REPO_NAME
+                value: Headway
+              - key: HEADWAY_ADMIN_SESSION_SECRET
+                sync: false
+              - key: HEADWAY_ADMIN_OAUTH_PUBLIC_ORIGIN
+                value: https://kigya-headway-dev-admin.onrender.com
+
+      - name: prod
+        envVarGroups:
+          - name: headway-prod-shared
+            envVars:
+              - key: ENV
+                value: prod
+        services:
+          - name: kigya-headway-prod-gateway
+            type: web
+            runtime: docker
+            plan: starter
+            region: frankfurt
+            branch: client-headway/86-client-auth-flow
+            autoDeployTrigger: off
+            rootDir: server
+            dockerfilePath: docker/render/Gateway.Dockerfile
+            dockerContext: .
+            healthCheckPath: /healthz
+            envVars:
+              - fromGroup: headway-prod-shared
+              - key: PORT
+                value: "8080"
+              - key: GATEWAY_SERVICE_HOST
+                value: "0.0.0.0"
+              - key: GATEWAY_SERVICE_PORT
+                value: "8080"
+              - key: AUTH_SERVICE_HOST
+                fromService:
+                  name: kigya-headway-prod-auth
+                  type: pserv
+                  property: host
+              - key: AUTH_SERVICE_PORT
+                fromService:
+                  name: kigya-headway-prod-auth
+                  type: pserv
+                  property: port
+              - key: DATABASE_SERVICE_HOST
+                fromService:
+                  name: kigya-headway-prod-database
+                  type: pserv
+                  property: host
+              - key: DATABASE_SERVICE_PORT
+                fromService:
+                  name: kigya-headway-prod-database
+                  type: pserv
+                  property: port
+              - key: HOME_SERVICE_HOST
+                fromService:
+                  name: kigya-headway-prod-home
+                  type: pserv
+                  property: host
+              - key: HOME_SERVICE_PORT
+                fromService:
+                  name: kigya-headway-prod-home
+                  type: pserv
+                  property: port
+
+          - name: kigya-headway-prod-auth
+            type: pserv
+            runtime: docker
+            plan: starter
+            region: frankfurt
+            branch: client-headway/86-client-auth-flow
+            autoDeployTrigger: off
+            rootDir: server
+            dockerfilePath: docker/render/Auth.Dockerfile
+            dockerContext: .
+            envVars:
+              - fromGroup: headway-prod-shared
+              - key: PORT
+                value: "8081"
+              - key: AUTH_SERVICE_SELF_HOST
+                value: "0.0.0.0"
+              - key: AUTH_SERVICE_PORT
+                value: "8081"
+              - key: DATABASE_SERVICE_HOST
+                fromService:
+                  name: kigya-headway-prod-database
+                  type: pserv
+                  property: host
+              - key: DATABASE_SERVICE_PORT
+                fromService:
+                  name: kigya-headway-prod-database
+                  type: pserv
+                  property: port
+              - key: JWT_ISSUER
+                value: headway-auth
+              - key: JWT_AUDIENCE
+                value: headway-gateway
+              - key: JWT_ACCESS_SECRET
+                sync: false
+              - key: JWT_REFRESH_SECRET
+                sync: false
+              - key: JWT_ACCESS_TTL_SEC
+                value: "300"
+              - key: JWT_GUEST_SECRET
+                sync: false
+              - key: JWT_GUEST_TTL_SEC
+                value: "86400"
+              - key: GOOGLE_TOKEN_AUDIENCE
+                value: 658272377808-alf63nc9km4tjgv0dr6lltfqfo1jshqb.apps.googleusercontent.com
+
+          - name: kigya-headway-prod-database
+            type: pserv
+            runtime: docker
+            plan: starter
+            region: frankfurt
+            branch: client-headway/86-client-auth-flow
+            autoDeployTrigger: off
+            rootDir: server
+            dockerfilePath: docker/render/Database.Dockerfile
+            dockerContext: .
+            envVars:
+              - fromGroup: headway-prod-shared
+              - key: PORT
+                value: "8082"
+              - key: DATABASE_SELF_SERVICE_HOST
+                value: "0.0.0.0"
+              - key: DATABASE_SERVICE_PORT
+                value: "8082"
+              - key: DATABASE_HOST_URL
+                value: aws-1-eu-west-1.pooler.supabase.com
+              - key: DATABASE_PORT
+                value: "5432"
+              - key: DATABASE_NAME
+                value: postgres
+              - key: DATABASE_USER
+                value: postgres.lhdkfjlltgnxrttrqfla
+              - key: DATABASE_PASSWORD
+                sync: false
+              - key: DATABASE_SSL_MODE
+                value: disable
+              - key: DATABASE_POOL_SIZE
+                value: "3"
+
+          - name: kigya-headway-prod-home
+            type: pserv
+            runtime: docker
+            plan: starter
+            region: frankfurt
+            branch: client-headway/86-client-auth-flow
+            autoDeployTrigger: off
+            rootDir: server
+            dockerfilePath: docker/render/Home.Dockerfile
+            dockerContext: .
+            envVars:
+              - fromGroup: headway-prod-shared
+              - key: PORT
+                value: "8084"
+              - key: HOME_SERVICE_SELF_HOST
+                value: "0.0.0.0"
+              - key: HOME_SERVICE_PORT
+                value: "8084"
+              - key: HOME_ICONS_PUBLIC_BASE_URL
+                value: https://lhdkfjlltgnxrttrqfla.supabase.co/storage/v1/object/public/icons
+
+          - name: kigya-headway-prod-admin
+            type: web
+            runtime: docker
+            plan: free
+            region: frankfurt
+            branch: client-headway/86-client-auth-flow
+            autoDeployTrigger: off
+            rootDir: server
+            dockerfilePath: docker/render/Admin.Dockerfile
+            dockerContext: .
+            healthCheckPath: /internal/v1/admin/healthz
+            envVars:
+              - fromGroup: headway-prod-shared
+              - key: PORT
+                value: "8083"
+              - key: ADMIN_SERVICE_HOST
+                value: "0.0.0.0"
+              - key: ADMIN_SERVICE_PORT
+                value: "8083"
+              - key: DATABASE_SERVICE_HOST
+                fromService:
+                  name: kigya-headway-prod-database
+                  type: pserv
+                  property: host
+              - key: DATABASE_SERVICE_PORT
+                fromService:
+                  name: kigya-headway-prod-database
+                  type: pserv
+                  property: port
+              - key: HEADWAY_GITHUB_OAUTH_CLIENT_ID
+                value: Ov23lilAEAUJM7Vn9CpX
+              - key: HEADWAY_GITHUB_OAUTH_CLIENT_SECRET
+                sync: false
+              - key: HEADWAY_REPO_OWNER
+                value: kigya
+              - key: HEADWAY_REPO_NAME
+                value: Headway
+              - key: HEADWAY_ADMIN_SESSION_SECRET
+                sync: false
+              - key: HEADWAY_ADMIN_OAUTH_PUBLIC_ORIGIN
+                value: https://kigya-headway-prod-admin.onrender.com

--- a/server/admin/internal/src/main/kotlin/dev/kigya/headway/admin/internal/presentation/plugin/AdminStatusPages.kt
+++ b/server/admin/internal/src/main/kotlin/dev/kigya/headway/admin/internal/presentation/plugin/AdminStatusPages.kt
@@ -1,25 +1,28 @@
 package dev.kigya.headway.admin.internal.presentation.plugin
 
 import dev.kigya.headway.admin.internal.core.exception.AdminException
+import dev.kigya.headway.common.extension.describeForHttpStatusText
 import dev.kigya.headway.common.extension.handleDefaultExceptions
+import io.ktor.http.ContentType
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.plugins.statuspages.StatusPagesConfig
-import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
 
 internal fun Application.adminStatusPages() {
     install(StatusPages) {
-        handleDefaultExceptions()
         handleAdminExceptions()
+        handleDefaultExceptions()
     }
 }
 
 private fun StatusPagesConfig.handleAdminExceptions() {
     exception<AdminException> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Error"),
+            contentType = ContentType.Text.Plain,
             status = exception.httpStatus,
-            message = exception.message,
         )
     }
 }

--- a/server/admin/internal/src/test/kotlin/dev/kigya/headway/admin/internal/presentation/AdminRoutesTest.kt
+++ b/server/admin/internal/src/test/kotlin/dev/kigya/headway/admin/internal/presentation/AdminRoutesTest.kt
@@ -224,6 +224,6 @@ private val invitedUser = DatabaseUser(
     updatedAt = 1_000L,
 )
 
-private const val INVITE_REQUEST_BODY = """{"email":"new.user@headway.test","role":"MANAGER","department":"ANDROID"}"""
-
 private fun String.compactWhitespace(): String = replace(Regex("\\s+"), "")
+
+private const val INVITE_REQUEST_BODY = """{"email":"new.user@headway.test","role":"MANAGER","department":"ANDROID"}"""

--- a/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/core/ConfigurationValues.kt
+++ b/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/core/ConfigurationValues.kt
@@ -39,8 +39,16 @@ internal object ConfigurationValues {
     val JWT_GUEST_TTL_SEC: Long
         get() = longEnv(EnvKeys.JWT_GUEST_TTL_SEC).takeIf { it > 0 } ?: DefaultValues.JWT_GUEST_TTL_SEC
 
-    val GOOGLE_TOKEN_AUDIENCE: String = stringEnv(EnvKeys.GOOGLE_TOKEN_AUDIENCE)
+    val GOOGLE_TOKEN_AUDIENCES: List<String> = stringEnv(EnvKeys.GOOGLE_TOKEN_AUDIENCE)
         .ifBlank { throw IllegalArgumentException("GOOGLE_TOKEN_AUDIENCE must be set") }
+        .split(',')
+        .asSequence()
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .toList()
+        .also { audiences ->
+            require(audiences.isNotEmpty()) { "GOOGLE_TOKEN_AUDIENCE must list at least one client id" }
+        }
 
     fun validateSecrets() {
         if (CommonConfigurationValues.environment.isProd) {

--- a/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/data/repository/DatabaseRepository.kt
+++ b/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/data/repository/DatabaseRepository.kt
@@ -20,8 +20,6 @@ import io.ktor.http.contentType
 import java.time.OffsetDateTime
 import java.util.UUID
 
-private const val DATABASE_DEPENDENCY_NAME = "database"
-
 class DatabaseRepository(
     private val httpClient: HttpClient,
 ) : DatabaseRepositoryContract {
@@ -169,3 +167,5 @@ class DatabaseRepository(
         }
     }
 }
+
+private const val DATABASE_DEPENDENCY_NAME = "database"

--- a/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/data/verifier/GoogleIdTokenVerifier.kt
+++ b/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/data/verifier/GoogleIdTokenVerifier.kt
@@ -4,9 +4,8 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier
 import com.google.api.client.http.javanet.NetHttpTransport
 import com.google.api.client.json.gson.GsonFactory
 import dev.kigya.headway.auth.api.model.`in`.AuthGoogleUserPayloadDto
-import dev.kigya.headway.auth.internal.core.ConfigurationValues.GOOGLE_TOKEN_AUDIENCE
+import dev.kigya.headway.auth.internal.core.ConfigurationValues.GOOGLE_TOKEN_AUDIENCES
 import dev.kigya.headway.auth.internal.domain.error.AuthException
-import java.util.Collections
 
 internal class GoogleIdTokenVerifier : GoogleTokenVerifierContract {
 
@@ -14,7 +13,7 @@ internal class GoogleIdTokenVerifier : GoogleTokenVerifierContract {
         NetHttpTransport(),
         GsonFactory.getDefaultInstance(),
     )
-        .setAudience(Collections.singletonList(GOOGLE_TOKEN_AUDIENCE))
+        .setAudience(GOOGLE_TOKEN_AUDIENCES)
         .build()
 
     override suspend fun verify(tokenString: String): AuthGoogleUserPayloadDto = try {

--- a/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/domain/usecase/LoginWithGoogleUseCase.kt
+++ b/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/domain/usecase/LoginWithGoogleUseCase.kt
@@ -24,10 +24,15 @@ internal class LoginWithGoogleUseCase(
     ): AuthGoogleLoginResponse {
         val googleUser = googleTokenVerifier.verify(tokenString = idToken)
 
+        val displayName = resolveGoogleDisplayName(
+            name = googleUser.name,
+            email = googleUser.email,
+        )
+
         val user = databaseRepository.upsertGoogleUser(
             googleId = googleUser.googleId,
             email = googleUser.email,
-            name = googleUser.name,
+            name = displayName,
             avatarUrl = googleUser.pictureUrl,
         )
 
@@ -55,5 +60,22 @@ internal class LoginWithGoogleUseCase(
         )
     }
 }
+
+private fun resolveGoogleDisplayName(
+    name: String,
+    email: String,
+): String {
+    val trimmedName = name.trim()
+    if (trimmedName.isNotEmpty()) {
+        return trimmedName
+    }
+    val localPart = email.substringBefore('@').trim()
+    if (localPart.isNotEmpty()) {
+        return localPart
+    }
+    return DEFAULT_GOOGLE_DISPLAY_NAME
+}
+
+private const val DEFAULT_GOOGLE_DISPLAY_NAME: String = "User"
 
 private const val REFRESH_ALIVE_MONTHS = 3L

--- a/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/presentation/plugin/AuthStatusPages.kt
+++ b/server/auth/internal/src/main/kotlin/dev/kigya/headway/auth/internal/presentation/plugin/AuthStatusPages.kt
@@ -1,72 +1,85 @@
 package dev.kigya.headway.auth.internal.presentation.plugin
 
 import dev.kigya.headway.auth.internal.domain.error.AuthException
+import dev.kigya.headway.common.extension.describeForHttpStatusText
 import dev.kigya.headway.common.extension.handleDefaultExceptions
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.plugins.statuspages.StatusPagesConfig
-import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
 
 internal fun Application.authStatusPages() {
     install(StatusPages) {
-        handleDefaultExceptions()
         handleAuthExceptions()
+        handleDefaultExceptions()
     }
 }
 
 private fun StatusPagesConfig.handleAuthExceptions() {
     exception<AuthException.InvalidRequest> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Invalid request"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.BadRequest,
-            message = exception.message,
         )
     }
 
     exception<AuthException.Unauthorized> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Unauthorized"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.Unauthorized,
-            message = exception.message,
         )
     }
 
     exception<AuthException.UserNotInvited> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Forbidden"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.Forbidden,
-            message = exception.message,
         )
     }
 
     exception<AuthException.UserNotActive> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Forbidden"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.Forbidden,
-            message = exception.message,
         )
     }
 
     exception<AuthException.Forbidden> { call, exception ->
-        call.respond(HttpStatusCode.Forbidden, exception.message)
+        call.respondText(
+            text = exception.describeForHttpStatusText("Forbidden"),
+            contentType = ContentType.Text.Plain,
+            status = HttpStatusCode.Forbidden,
+        )
     }
 
     exception<AuthException.IdentityConflict> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Conflict"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.Conflict,
-            message = exception.message,
         )
     }
 
     exception<AuthException.DependencyUnavailable> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Service unavailable"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.ServiceUnavailable,
-            message = exception.message,
         )
     }
 
     exception<AuthException.UpstreamProtocol> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Bad gateway"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.BadGateway,
-            message = exception.message,
         )
     }
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -63,3 +63,9 @@ githubEnvSync {
 
     environments.set(listOf("dev", "prod"))
 }
+
+tasks.register("githubEnvSync") {
+    group = "github env sync"
+    description = "Alias for syncGithubEnv — pulls GitHub variables and renders docker env templates"
+    dependsOn(tasks.named("syncGithubEnv"))
+}

--- a/server/common/src/main/kotlin/dev/kigya/headway/common/extension/StatusPagesConfigExtension.kt
+++ b/server/common/src/main/kotlin/dev/kigya/headway/common/extension/StatusPagesConfigExtension.kt
@@ -1,5 +1,6 @@
 package dev.kigya.headway.common.extension
 
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.CannotTransformContentToTypeException
@@ -9,76 +10,94 @@ import io.ktor.server.plugins.ParameterConversionException
 import io.ktor.server.plugins.PayloadTooLargeException
 import io.ktor.server.plugins.UnsupportedMediaTypeException
 import io.ktor.server.plugins.statuspages.StatusPagesConfig
-import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
 
 fun StatusPagesConfig.handleDefaultExceptions() {
     exception<BadRequestException> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Bad request"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.BadRequest,
-            message = exception.message.orEmpty(),
         )
     }
 
     exception<NotFoundException> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Not found"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.NotFound,
-            message = exception.message.orEmpty(),
         )
     }
 
     exception<MissingRequestParameterException> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Bad request"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.BadRequest,
-            message = exception.message.orEmpty(),
         )
     }
 
     exception<ParameterConversionException> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Bad request"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.BadRequest,
-            message = exception.message.orEmpty(),
         )
     }
 
     exception<CannotTransformContentToTypeException> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Bad request"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.BadRequest,
-            message = exception.message.orEmpty(),
         )
     }
 
     exception<UnsupportedMediaTypeException> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Unsupported media type"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.UnsupportedMediaType,
-            message = exception.message.orEmpty(),
         )
     }
 
     exception<PayloadTooLargeException> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Payload too large"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.PayloadTooLarge,
-            message = exception.message.orEmpty(),
         )
     }
 
     exception<IllegalStateException> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Internal server error"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.InternalServerError,
-            message = exception.message.orEmpty(),
         )
     }
 
     exception<SecurityException> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Unauthorized"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.Unauthorized,
-            message = exception.message.orEmpty(),
         )
     }
 
     exception<Throwable> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Internal server error"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.InternalServerError,
-            message = exception.message.orEmpty(),
         )
     }
+}
+
+fun Throwable.describeForHttpStatusText(fallback: String): String {
+    val trimmed = message?.trim().orEmpty()
+    if (trimmed.isNotEmpty()) {
+        return trimmed
+    }
+    return this::class.simpleName ?: fallback
 }

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/repository/LearningQuestionsReadRepository.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/repository/LearningQuestionsReadRepository.kt
@@ -223,15 +223,15 @@ private fun buildPage(
     val startIndex = when (afterQuestionId) {
         null -> 0
         else -> {
-            val idx = allIds.indexOf(afterQuestionId)
-            if (idx < 0) {
+            val afterQuestionIndex = allIds.indexOf(afterQuestionId)
+            if (afterQuestionIndex < 0) {
                 return DatabaseLearningPageResponseDto(
                     items = emptyList(),
                     resumeHard = null,
                     resumeSoft = null,
                 )
             }
-            idx + 1
+            afterQuestionIndex + 1
         }
     }
     val sliceIds = allIds.drop(startIndex).take(limit)

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/repository/PreparationRepository.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/data/repository/PreparationRepository.kt
@@ -682,8 +682,8 @@ private fun nextRecommendedFormat(
 }
 
 private fun isUniqueActiveSessionViolation(e: ExposedSQLException): Boolean {
-    val msg = e.message.orEmpty() + e.cause?.message.orEmpty()
-    return msg.contains("preparation_session_one_active_per_pair_idx", ignoreCase = true)
+    val combinedExceptionMessage = e.message.orEmpty() + e.cause?.message.orEmpty()
+    return combinedExceptionMessage.contains("preparation_session_one_active_per_pair_idx", ignoreCase = true)
 }
 
 private fun parseStringListJson(raw: String): List<String> = runCatching {

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/presentation/plugin/DatabaseStatusPages.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/presentation/plugin/DatabaseStatusPages.kt
@@ -1,89 +1,101 @@
 package dev.kigya.headway.database.internal.presentation.plugin
 
+import dev.kigya.headway.common.extension.describeForHttpStatusText
 import dev.kigya.headway.common.extension.handleDefaultExceptions
 import dev.kigya.headway.database.internal.domain.error.DatabaseException
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.plugins.statuspages.StatusPagesConfig
-import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
 
 internal fun Application.databaseStatusPages() {
     install(StatusPages) {
-        handleDefaultExceptions()
         handleDatabaseExceptions()
+        handleDefaultExceptions()
     }
 }
 
 private fun StatusPagesConfig.handleDatabaseExceptions() {
     exception<DatabaseException.InvalidRequest> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Bad request"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.BadRequest,
-            message = exception.message,
         )
     }
 
     exception<DatabaseException.Unauthorized> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Unauthorized"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.Unauthorized,
-            message = exception.message,
         )
     }
 
     exception<DatabaseException.UserNotInvited> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Forbidden"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.Forbidden,
-            message = exception.message,
         )
     }
 
     exception<DatabaseException.NotFound> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Not found"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.NotFound,
-            message = exception.message,
         )
     }
 
     exception<DatabaseException.PreparationForbidden> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Forbidden"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.Forbidden,
-            message = exception.message,
         )
     }
 
     exception<DatabaseException.PreparationConflict> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Conflict"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.Conflict,
-            message = exception.message,
         )
     }
 
     exception<DatabaseException.Forbidden> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Forbidden"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.Forbidden,
-            message = exception.message,
         )
     }
 
     exception<DatabaseException.UserAlreadyExists> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Conflict"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.Conflict,
-            message = exception.user,
         )
     }
 
     exception<DatabaseException.Conflict> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Conflict"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.Conflict,
-            message = exception.message,
         )
     }
 
     exception<DatabaseException.DependencyUnavailable> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Service unavailable"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.ServiceUnavailable,
-            message = exception.message,
         )
     }
 }

--- a/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/presentation/routing/UsersRouting.kt
+++ b/server/database/internal/src/main/kotlin/dev/kigya/headway/database/internal/presentation/routing/UsersRouting.kt
@@ -68,11 +68,14 @@ private fun Route.upsertGoogleUser(upsertGoogleUser: UpsertGoogleUserUseCase) {
 
         val googleId = body.googleId.trim()
         val email = body.email.trim()
-        val name = body.name.trim()
         val avatarUrl = body.avatarUrl?.trim()
         if (googleId.isBlank()) throw BadRequestException("GoogleId is blank")
         if (email.isBlank()) throw BadRequestException("Email is blank")
-        if (name.isBlank()) throw BadRequestException("Name is blank")
+
+        val name = resolveUpsertGoogleDisplayName(
+            rawName = body.name,
+            email = email,
+        )
 
         val user = upsertGoogleUser(
             googleId = googleId,
@@ -102,3 +105,20 @@ private fun Route.inviteUser(inviteUser: InviteUserUseCase) {
         call.respond(HttpStatusCode.Created, user)
     }
 }
+
+private fun resolveUpsertGoogleDisplayName(
+    rawName: String,
+    email: String,
+): String {
+    val trimmedName = rawName.trim()
+    if (trimmedName.isNotEmpty()) {
+        return trimmedName
+    }
+    val localPart = email.substringBefore('@').trim()
+    if (localPart.isNotEmpty()) {
+        return localPart
+    }
+    return DEFAULT_UPSERT_GOOGLE_DISPLAY_NAME
+}
+
+private const val DEFAULT_UPSERT_GOOGLE_DISPLAY_NAME: String = "User"

--- a/server/docker/render/Admin.Dockerfile
+++ b/server/docker/render/Admin.Dockerfile
@@ -1,0 +1,12 @@
+FROM gradle:8.14.0-jdk17 AS build
+WORKDIR /src
+COPY . .
+
+RUN --mount=type=cache,target=/home/gradle/.gradle \
+  ./gradlew --no-daemon -Dorg.gradle.vfs.watch=false -Dorg.gradle.configuration-cache=false \
+  admin:internal:installDist
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /src/admin/internal/build/install/admin/ ./
+CMD ["build/admin"]

--- a/server/docker/render/Auth.Dockerfile
+++ b/server/docker/render/Auth.Dockerfile
@@ -1,0 +1,12 @@
+FROM gradle:8.14.0-jdk17 AS build
+WORKDIR /src
+COPY . .
+
+RUN --mount=type=cache,target=/home/gradle/.gradle \
+  ./gradlew --no-daemon -Dorg.gradle.vfs.watch=false -Dorg.gradle.configuration-cache=false \
+  auth:internal:installDist
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /src/auth/internal/build/install/auth/ ./
+CMD ["build/auth"]

--- a/server/docker/render/Database.Dockerfile
+++ b/server/docker/render/Database.Dockerfile
@@ -1,0 +1,12 @@
+FROM gradle:8.14.0-jdk17 AS build
+WORKDIR /src
+COPY . .
+
+RUN --mount=type=cache,target=/home/gradle/.gradle \
+  ./gradlew --no-daemon -Dorg.gradle.vfs.watch=false -Dorg.gradle.configuration-cache=false \
+  database:internal:installDist
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /src/database/internal/build/install/database/ ./
+CMD ["build/database"]

--- a/server/docker/render/Gateway.Dockerfile
+++ b/server/docker/render/Gateway.Dockerfile
@@ -1,0 +1,12 @@
+FROM gradle:8.14.0-jdk17 AS build
+WORKDIR /src
+COPY . .
+
+RUN --mount=type=cache,target=/home/gradle/.gradle \
+  ./gradlew --no-daemon -Dorg.gradle.vfs.watch=false -Dorg.gradle.configuration-cache=false \
+  gateway:installDist
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /src/gateway/build/install/gateway/ ./
+CMD ["build/gateway"]

--- a/server/docker/render/Home.Dockerfile
+++ b/server/docker/render/Home.Dockerfile
@@ -1,0 +1,12 @@
+FROM gradle:8.14.0-jdk17 AS build
+WORKDIR /src
+COPY . .
+
+RUN --mount=type=cache,target=/home/gradle/.gradle \
+  ./gradlew --no-daemon -Dorg.gradle.vfs.watch=false -Dorg.gradle.configuration-cache=false \
+  home:internal:installDist
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /src/home/internal/build/install/home/ ./
+CMD ["build/home"]

--- a/server/docker/template/env.auth.template
+++ b/server/docker/template/env.auth.template
@@ -13,3 +13,4 @@ JWT_GUEST_SECRET=${JWT_GUEST_SECRET}
 JWT_GUEST_TTL_SEC=${JWT_GUEST_TTL_SEC}
 
 GOOGLE_TOKEN_AUDIENCE=${GOOGLE_TOKEN_AUDIENCE}
+# Comma-separated list of OAuth client IDs allowed in Google id_token "aud" when more than one client issues tokens.

--- a/server/gateway/build.gradle.kts
+++ b/server/gateway/build.gradle.kts
@@ -25,6 +25,7 @@ microserviceDependencies {
     libs {
         implementation(logback)
         implementation(ktor.serverCore)
+        implementation(ktor.serverCors)
         implementation(ktor.serverNetty)
         implementation(ktor.negotiation)
         implementation(ktor.serialization)

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/core/http/UpstreamHttpErrorMapper.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/core/http/UpstreamHttpErrorMapper.kt
@@ -3,12 +3,23 @@ package dev.kigya.headway.gateway.core.http
 import dev.kigya.headway.database.api.model.DatabasePreparationErrorCodes
 import dev.kigya.headway.gateway.core.exception.GatewayErrorReason
 import dev.kigya.headway.gateway.core.exception.GatewayException
+import io.ktor.client.call.body
 import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
+import org.slf4j.LoggerFactory
+
+private val upstreamHttpErrorLog = LoggerFactory.getLogger("dev.kigya.headway.gateway.UpstreamHttp")
 
 internal suspend fun HttpResponse.toGatewayException(dependency: String): GatewayException {
     val bodyMsg = safeBodyMessage()
+    if (bodyMsg == null && status == HttpStatusCode.BadRequest) {
+        upstreamHttpErrorLog.warn(
+            "Empty error body from dependency={} method={} url={}",
+            dependency,
+            call.request.method.value,
+            call.request.url,
+        )
+    }
 
     return when (status) {
         HttpStatusCode.BadRequest ->
@@ -67,11 +78,16 @@ private fun forbiddenReason(bodyMsg: String?): GatewayErrorReason = when (bodyMs
 }
 
 private suspend fun HttpResponse.safeBodyMessage(): String? {
-    val raw = runCatching { bodyAsText() }.getOrNull()?.trim().orEmpty()
-    if (raw.isBlank()) return null
-    return raw
-        .replace(Regex("\\s+"), " ")
-        .take(MAX_ERROR_BODY_LEN)
+    val fromBytes = runCatching { body<ByteArray>() }.getOrNull()
+    if (fromBytes != null && fromBytes.isNotEmpty()) {
+        val decoded = fromBytes.decodeToString().trim()
+        if (decoded.isNotEmpty()) {
+            return decoded
+                .replace(Regex("\\s+"), " ")
+                .take(MAX_ERROR_BODY_LEN)
+        }
+    }
+    return null
 }
 
 private const val MAX_ERROR_BODY_LEN = 2048

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/core/presentation/GatewayGraphqlErrorMapper.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/core/presentation/GatewayGraphqlErrorMapper.kt
@@ -25,31 +25,34 @@ internal object GatewayGraphqlErrorMapper {
             )
 
             is KtorBadRequestException -> {
-                val msg = original.message ?: DEFAULT_BAD_REQUEST
+                val badRequestMessage = original.message ?: DEFAULT_BAD_REQUEST
                 GraphQlErrorEnvelope(
-                    message = msg,
+                    message = badRequestMessage,
                     code = GatewayErrorCode.BAD_REQUEST,
                     extensions = extensionsFor(
                         GatewayException.InvalidRequest(
                             reason = GatewayErrorReason.BAD_REQUEST,
-                            message = msg,
+                            message = badRequestMessage,
                             cause = original,
                         ),
                     ),
                 )
             }
 
-            is IllegalArgumentException -> GraphQlErrorEnvelope(
-                message = DEFAULT_BAD_REQUEST,
-                code = GatewayErrorCode.BAD_REQUEST,
-                extensions = extensionsFor(
-                    GatewayException.InvalidRequest(
-                        reason = GatewayErrorReason.BAD_REQUEST,
-                        message = DEFAULT_BAD_REQUEST,
-                        cause = original,
+            is IllegalArgumentException -> {
+                val detail = illegalArgumentDetail(original)
+                GraphQlErrorEnvelope(
+                    message = detail,
+                    code = GatewayErrorCode.BAD_REQUEST,
+                    extensions = extensionsFor(
+                        GatewayException.InvalidRequest(
+                            reason = GatewayErrorReason.BAD_REQUEST,
+                            message = detail,
+                            cause = original,
+                        ),
                     ),
-                ),
-            )
+                )
+            }
 
             else -> GraphQlErrorEnvelope(
                 message = "Internal server error",
@@ -74,6 +77,14 @@ internal object GatewayGraphqlErrorMapper {
         val exception = t as? ExecutionException
         return exception?.originalError ?: t
     }
+}
+
+private fun illegalArgumentDetail(exception: IllegalArgumentException): String {
+    val fromMessage = exception.message?.trim().orEmpty()
+    if (fromMessage.isNotEmpty()) {
+        return fromMessage
+    }
+    return exception::class.simpleName ?: DEFAULT_BAD_REQUEST
 }
 
 private const val DEFAULT_BAD_REQUEST = "Bad request"

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/kgraphql/LenientKGraphQL.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/kgraphql/LenientKGraphQL.kt
@@ -1,0 +1,158 @@
+package dev.kigya.headway.gateway.kgraphql
+
+import com.apurebase.kgraphql.ContextBuilder
+import com.apurebase.kgraphql.GraphQLError
+import com.apurebase.kgraphql.GraphqlRequest
+import com.apurebase.kgraphql.KGraphQL
+import com.apurebase.kgraphql.KtorGraphQLConfiguration
+import com.apurebase.kgraphql.context
+import com.apurebase.kgraphql.schema.Schema
+import com.apurebase.kgraphql.schema.dsl.SchemaBuilder
+import com.apurebase.kgraphql.schema.dsl.SchemaConfigurationDSL
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.ApplicationCallPipeline
+import io.ktor.server.application.Plugin
+import io.ktor.server.application.install
+import io.ktor.server.application.pluginOrNull
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respondBytes
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.RoutingRoot
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.util.AttributeKey
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.json.Json
+
+internal class LenientKGraphQL(val schema: Schema) {
+    class Configuration : SchemaConfigurationDSL() {
+        fun schema(block: SchemaBuilder.() -> Unit) {
+            schemaBlock = block
+        }
+
+        var playground: Boolean = false
+
+        var endpoint: String = "/graphql"
+
+        fun context(block: ContextBuilder.(ApplicationCall) -> Unit) {
+            contextSetup = block
+        }
+
+        fun wrap(block: Route.(next: Route.() -> Unit) -> Unit) {
+            wrapWith = block
+        }
+
+        fun errorHandler(block: (e: Throwable) -> Throwable) {
+            errorHandler = block
+        }
+
+        internal var contextSetup: (ContextBuilder.(ApplicationCall) -> Unit)? = null
+        internal var wrapWith: (Route.(next: Route.() -> Unit) -> Unit)? = null
+        internal var errorHandler: ((Throwable) -> Throwable) = { e -> e }
+        internal var schemaBlock: (SchemaBuilder.() -> Unit)? = null
+    }
+
+    companion object Feature : Plugin<Application, Configuration, LenientKGraphQL> {
+        override val key = AttributeKey<LenientKGraphQL>("LenientKGraphQL")
+
+        private val rootFeature = FeatureInstance("LenientKGraphQL")
+
+        override fun install(
+            pipeline: Application,
+            configure: Configuration.() -> Unit,
+        ): LenientKGraphQL {
+            return rootFeature.install(pipeline, configure)
+        }
+    }
+
+    class FeatureInstance(featureKey: String = "LenientKGraphQL") :
+        Plugin<Application, Configuration, LenientKGraphQL> {
+        companion object {
+            private val playgroundHtml: ByteArray? by lazy {
+                KtorGraphQLConfiguration::class.java.classLoader.getResource("playground.html")?.readBytes()
+            }
+        }
+
+        override val key = AttributeKey<LenientKGraphQL>(featureKey)
+
+        override fun install(
+            pipeline: Application,
+            configure: Configuration.() -> Unit,
+        ): LenientKGraphQL {
+            val config = Configuration().apply(configure)
+            val schema = KGraphQL.schema {
+                configuration = config
+                config.schemaBlock?.let { it(this) }
+            }
+
+            val routing: Routing.() -> Unit = {
+                val routing: Route.() -> Unit = {
+                    route(config.endpoint) {
+                        post {
+                            val bodyAsText = call.receiveText()
+                            val request = graphqlRequestJson.decodeFromString(
+                                GraphqlRequest.serializer(),
+                                bodyAsText,
+                            )
+                            val graphQlContext = context {
+                                config.contextSetup?.let { it(this, call) }
+                            }
+                            val result = schema.execute(
+                                request = request.query,
+                                variables = request.variables.toString(),
+                                context = graphQlContext,
+                                operationName = request.operationName,
+                            )
+                            call.respondText(result, contentType = ContentType.Application.Json)
+                        }
+                        get {
+                            val schemaRequested = call.request.queryParameters["schema"] != null
+                            if (schemaRequested && config.introspection) {
+                                call.respondText(schema.printSchema())
+                            } else if (config.playground) {
+                                playgroundHtml?.let {
+                                    call.respondBytes(it, contentType = ContentType.Text.Html)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                config.wrapWith?.let { it(this, routing) } ?: routing(this)
+            }
+
+            pipeline.pluginOrNull(RoutingRoot)?.apply(routing)
+                ?: pipeline.install(RoutingRoot, routing)
+
+            pipeline.intercept(ApplicationCallPipeline.Monitoring) {
+                try {
+                    coroutineScope {
+                        proceed()
+                    }
+                } catch (e: Throwable) {
+                    val error = config.errorHandler(e)
+                    if (error !is GraphQLError) {
+                        throw e
+                    }
+
+                    context.respondText(
+                        error.serialize(),
+                        ContentType.Application.Json,
+                        HttpStatusCode.OK,
+                    )
+                }
+            }
+            return LenientKGraphQL(schema)
+        }
+    }
+}
+
+private val graphqlRequestJson = Json {
+    ignoreUnknownKeys = true
+}

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/presentation/GatewayApi.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/presentation/GatewayApi.kt
@@ -1,6 +1,8 @@
 package dev.kigya.headway.gateway.presentation
 
 import com.apurebase.kgraphql.GraphQLError
+import dev.kigya.headway.common.extension.defaultResources
+import dev.kigya.headway.common.extension.healthzRouting
 import dev.kigya.headway.gateway.core.exception.GatewayErrorCode
 import dev.kigya.headway.gateway.core.presentation.GatewayGraphqlErrorMapper
 import dev.kigya.headway.gateway.graphql.GraphqlRequestContext
@@ -25,8 +27,13 @@ import io.ktor.http.HttpHeaders
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.application.log
+import io.ktor.server.routing.routing
 
 internal fun Application.installGatewayApi(bindings: GatewayApiBindings) {
+    defaultResources()
+    routing {
+        healthzRouting()
+    }
     installHeadwayGatewayCors(environment = bindings.environment)
     install(LenientKGraphQL) {
         playground = !bindings.environment.isProd

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/presentation/GatewayApi.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/presentation/GatewayApi.kt
@@ -1,6 +1,5 @@
 package dev.kigya.headway.gateway.presentation
 
-import com.apurebase.kgraphql.GraphQL
 import com.apurebase.kgraphql.GraphQLError
 import dev.kigya.headway.gateway.core.exception.GatewayErrorCode
 import dev.kigya.headway.gateway.core.presentation.GatewayGraphqlErrorMapper
@@ -8,6 +7,7 @@ import dev.kigya.headway.gateway.graphql.GraphqlRequestContext
 import dev.kigya.headway.gateway.graphql.parseGatewayAppLocale
 import dev.kigya.headway.gateway.graphql.stringScalarLong
 import dev.kigya.headway.gateway.graphql.stringScalarUUID
+import dev.kigya.headway.gateway.kgraphql.LenientKGraphQL
 import dev.kigya.headway.gateway.model.GatewayGoogleLoginResponse
 import dev.kigya.headway.gateway.model.GatewayGuestLoginResponse
 import dev.kigya.headway.gateway.model.GatewayRefreshAccessTokenResponse
@@ -27,14 +27,15 @@ import io.ktor.server.application.install
 import io.ktor.server.application.log
 
 internal fun Application.installGatewayApi(bindings: GatewayApiBindings) {
-    install(GraphQL) {
+    installHeadwayGatewayCors(environment = bindings.environment)
+    install(LenientKGraphQL) {
         playground = !bindings.environment.isProd
         endpoint = GatewayHttpRoute.GraphQL.path
         context { call ->
             +GraphqlRequestContext(
                 authorizationHeader = call.request.headers[HttpHeaders.Authorization],
                 appLocale = parseGatewayAppLocale(
-                    xHeadwayLocale = call.request.headers[X_HEADWAY_LOCALE_HEADER],
+                    xHeadwayLocale = call.request.headers[X_HEADWAY_LOCALE_HEADER_NAME],
                     acceptLanguage = call.request.headers[HttpHeaders.AcceptLanguage],
                 ),
             )
@@ -100,5 +101,3 @@ internal fun Application.installGatewayApi(bindings: GatewayApiBindings) {
         }
     }
 }
-
-private const val X_HEADWAY_LOCALE_HEADER: String = "X-Headway-Locale"

--- a/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/presentation/GatewayCors.kt
+++ b/server/gateway/src/main/kotlin/dev/kigya/headway/gateway/presentation/GatewayCors.kt
@@ -1,0 +1,26 @@
+package dev.kigya.headway.gateway.presentation
+
+import dev.kigya.headway.common.util.Environment
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.cors.routing.CORS
+
+internal fun Application.installHeadwayGatewayCors(environment: Environment) {
+    if (environment.isProd) {
+        return
+    }
+    install(CORS) {
+        anyHost()
+        allowMethod(HttpMethod.Get)
+        allowMethod(HttpMethod.Post)
+        allowMethod(HttpMethod.Options)
+        allowHeader(HttpHeaders.Authorization)
+        allowHeader(HttpHeaders.ContentType)
+        allowHeader(X_HEADWAY_LOCALE_HEADER_NAME)
+        allowNonSimpleContentTypes = true
+    }
+}
+
+internal const val X_HEADWAY_LOCALE_HEADER_NAME: String = "X-Headway-Locale"

--- a/server/gateway/src/test/kotlin/dev/kigya/headway/gateway/core/http/UpstreamHttpErrorMapperTest.kt
+++ b/server/gateway/src/test/kotlin/dev/kigya/headway/gateway/core/http/UpstreamHttpErrorMapperTest.kt
@@ -23,9 +23,9 @@ class UpstreamHttpErrorMapperTest {
             status = HttpStatusCode.Conflict,
             body = DatabasePreparationErrorCodes.SCOPE_SESSION_CLOSED,
         ).get("http://test/")
-        val ex = response.toGatewayException("database")
-        assertTrue(ex is GatewayException.Conflict)
-        assertEquals(GatewayErrorReason.PREPARATION_SCOPE_SESSION_CLOSED, ex.reason)
+        val gatewayException = response.toGatewayException("database")
+        assertTrue(gatewayException is GatewayException.Conflict)
+        assertEquals(GatewayErrorReason.PREPARATION_SCOPE_SESSION_CLOSED, gatewayException.reason)
     }
 
     @Test
@@ -34,9 +34,9 @@ class UpstreamHttpErrorMapperTest {
             status = HttpStatusCode.Forbidden,
             body = DatabasePreparationErrorCodes.SUMMARY_REQUIRES_COMPLETED_SESSION,
         ).get("http://test/")
-        val ex = response.toGatewayException("database")
-        assertTrue(ex is GatewayException.Forbidden)
-        assertEquals(GatewayErrorReason.PREPARATION_SUMMARY_REQUIRES_COMPLETED_SESSION, ex.reason)
+        val gatewayException = response.toGatewayException("database")
+        assertTrue(gatewayException is GatewayException.Forbidden)
+        assertEquals(GatewayErrorReason.PREPARATION_SUMMARY_REQUIRES_COMPLETED_SESSION, gatewayException.reason)
     }
 
     @Test
@@ -45,9 +45,9 @@ class UpstreamHttpErrorMapperTest {
             status = HttpStatusCode.Conflict,
             body = "other",
         ).get("http://test/")
-        val ex = response.toGatewayException("database")
-        assertTrue(ex is GatewayException.Conflict)
-        assertEquals(GatewayErrorReason.IDENTITY_CONFLICT, ex.reason)
+        val gatewayException = response.toGatewayException("database")
+        assertTrue(gatewayException is GatewayException.Conflict)
+        assertEquals(GatewayErrorReason.IDENTITY_CONFLICT, gatewayException.reason)
     }
 
     @Test
@@ -56,9 +56,9 @@ class UpstreamHttpErrorMapperTest {
             status = HttpStatusCode.Forbidden,
             body = "nope",
         ).get("http://test/")
-        val ex = response.toGatewayException("database")
-        assertTrue(ex is GatewayException.Forbidden)
-        assertEquals(GatewayErrorReason.INSUFFICIENT_ROLE, ex.reason)
+        val gatewayException = response.toGatewayException("database")
+        assertTrue(gatewayException is GatewayException.Forbidden)
+        assertEquals(GatewayErrorReason.INSUFFICIENT_ROLE, gatewayException.reason)
     }
 
     private fun mockClient(

--- a/server/gateway/src/test/kotlin/dev/kigya/headway/gateway/core/presentation/GatewayGraphqlErrorMapperTest.kt
+++ b/server/gateway/src/test/kotlin/dev/kigya/headway/gateway/core/presentation/GatewayGraphqlErrorMapperTest.kt
@@ -24,8 +24,8 @@ class GatewayGraphqlErrorMapperTest {
 
     @Test
     fun `maps dependency unavailable with retryable and dependency`() {
-        val ex = GatewayException.DependencyUnavailable(dependency = "auth")
-        val envelope = GatewayGraphqlErrorMapper.map(ex)
+        val gatewayException = GatewayException.DependencyUnavailable(dependency = "auth")
+        val envelope = GatewayGraphqlErrorMapper.map(gatewayException)
 
         assertEquals(GatewayErrorCode.DEPENDENCY_UNAVAILABLE, envelope.code)
         assertEquals("dependency", envelope.extensions["category"])
@@ -36,8 +36,8 @@ class GatewayGraphqlErrorMapperTest {
 
     @Test
     fun `extensionsFor exposes upstream protocol fields`() {
-        val ex = GatewayException.UpstreamProtocol(dependency = "database", status = 418)
-        val ext = GatewayGraphqlErrorMapper.extensionsFor(ex)
+        val gatewayException = GatewayException.UpstreamProtocol(dependency = "database", status = 418)
+        val ext = GatewayGraphqlErrorMapper.extensionsFor(gatewayException)
 
         assertEquals("UPSTREAM_PROTOCOL", ext["reason"])
         assertEquals(418, ext["upstreamStatus"])
@@ -47,11 +47,11 @@ class GatewayGraphqlErrorMapperTest {
 
     @Test
     fun `maps guest forbidden`() {
-        val ex = GatewayException.Forbidden(
+        val gatewayException = GatewayException.Forbidden(
             reason = GatewayErrorReason.GUEST_NOT_ALLOWED,
             message = "Guests cannot invite users",
         )
-        val envelope = GatewayGraphqlErrorMapper.map(ex)
+        val envelope = GatewayGraphqlErrorMapper.map(gatewayException)
 
         assertEquals(GatewayErrorCode.FORBIDDEN, envelope.code)
         assertEquals(GatewayErrorCategory.AUTHORIZATION.name.lowercase(), envelope.extensions["category"])
@@ -60,11 +60,11 @@ class GatewayGraphqlErrorMapperTest {
 
     @Test
     fun `maps preparation scope session closed conflict reason`() {
-        val ex = GatewayException.Conflict(
+        val gatewayException = GatewayException.Conflict(
             message = "closed",
             reason = GatewayErrorReason.PREPARATION_SCOPE_SESSION_CLOSED,
         )
-        val envelope = GatewayGraphqlErrorMapper.map(ex)
+        val envelope = GatewayGraphqlErrorMapper.map(gatewayException)
 
         assertEquals(GatewayErrorCode.CONFLICT, envelope.code)
         assertEquals("PREPARATION_SCOPE_SESSION_CLOSED", envelope.extensions["reason"])

--- a/server/gateway/src/test/kotlin/dev/kigya/headway/gateway/data/repository/HomeRepositoryTest.kt
+++ b/server/gateway/src/test/kotlin/dev/kigya/headway/gateway/data/repository/HomeRepositoryTest.kt
@@ -89,10 +89,10 @@ class HomeRepositoryTest {
             respondError(HttpStatusCode.BadRequest)
         }
         val repo = HomeRepository(httpClient = homeGatewayHttpClient(engine))
-        val ex = assertFailsWith<GatewayException.InvalidRequest> {
+        val invalidRequestException = assertFailsWith<GatewayException.InvalidRequest> {
             runBlocking { repo.getHomeScreen(sampleRequest) }
         }
-        assertEquals(GatewayErrorReason.BAD_REQUEST, ex.reason)
+        assertEquals(GatewayErrorReason.BAD_REQUEST, invalidRequestException.reason)
     }
 
     @Test
@@ -102,22 +102,22 @@ class HomeRepositoryTest {
             respondError(HttpStatusCode.InternalServerError)
         }
         val repo = HomeRepository(httpClient = homeGatewayHttpClient(engine))
-        val ex = assertFailsWith<GatewayException.UpstreamProtocol> {
+        val upstreamProtocolException = assertFailsWith<GatewayException.UpstreamProtocol> {
             runBlocking { repo.getHomeScreen(sampleRequest) }
         }
-        assertEquals("home", ex.dependency)
-        assertEquals(500, ex.upstreamStatus)
+        assertEquals("home", upstreamProtocolException.dependency)
+        assertEquals(500, upstreamProtocolException.upstreamStatus)
     }
 
     @Test
     fun `maps transport failure to dependency unavailable`() {
         val engine = MockEngine { throw IOException("network") }
         val repo = HomeRepository(httpClient = homeGatewayHttpClient(engine))
-        val ex = assertFailsWith<GatewayException.DependencyUnavailable> {
+        val dependencyUnavailableException = assertFailsWith<GatewayException.DependencyUnavailable> {
             runBlocking { repo.getHomeScreen(sampleRequest) }
         }
-        assertEquals("home", ex.dependency)
-        assertTrue(ex.cause is IOException)
+        assertEquals("home", dependencyUnavailableException.dependency)
+        assertTrue(dependencyUnavailableException.cause is IOException)
     }
 
     private fun assertScreenPost(request: HttpRequestData) {

--- a/server/gateway/src/test/kotlin/dev/kigya/headway/gateway/domain/auth/GatewayAuthorizationPolicyPreparationTest.kt
+++ b/server/gateway/src/test/kotlin/dev/kigya/headway/gateway/domain/auth/GatewayAuthorizationPolicyPreparationTest.kt
@@ -14,7 +14,7 @@ class GatewayAuthorizationPolicyPreparationTest {
 
     @Test
     fun `preparation rejects guest principal`() {
-        val ex = assertFailsWith<GatewayException.Forbidden> {
+        val forbiddenException = assertFailsWith<GatewayException.Forbidden> {
             GatewayAuthorizationPolicy.ensure(
                 principal = GatewayPrincipal.Guest(
                     guestSessionId = UUID.fromString("00000000-0000-0000-0000-00000000abba"),
@@ -23,12 +23,12 @@ class GatewayAuthorizationPolicyPreparationTest {
                 operation = GatewayOperation.Preparation,
             )
         }
-        assertEquals(GatewayErrorReason.GUEST_NOT_ALLOWED, ex.reason)
+        assertEquals(GatewayErrorReason.GUEST_NOT_ALLOWED, forbiddenException.reason)
     }
 
     @Test
     fun `preparation rejects employee user`() {
-        val ex = assertFailsWith<GatewayException.Forbidden> {
+        val forbiddenException = assertFailsWith<GatewayException.Forbidden> {
             GatewayAuthorizationPolicy.ensure(
                 principal = GatewayPrincipal.User(
                     user = GatewayUser(
@@ -41,6 +41,6 @@ class GatewayAuthorizationPolicyPreparationTest {
                 operation = GatewayOperation.Preparation,
             )
         }
-        assertEquals(GatewayErrorReason.INSUFFICIENT_ROLE, ex.reason)
+        assertEquals(GatewayErrorReason.INSUFFICIENT_ROLE, forbiddenException.reason)
     }
 }

--- a/server/gradle/libs.versions.toml
+++ b/server/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negoti
 ktor-serialization = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-auth-jwt = { module = "io.ktor:ktor-server-auth-jwt", version.ref = "ktor" }
 ktor-serverCore = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }
+ktor-serverCors = { module = "io.ktor:ktor-server-cors-jvm", version.ref = "ktor" }
 ktor-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
 ktor-statusPages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
 ktor-serverNetty = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktor" }

--- a/server/home/internal/src/main/kotlin/dev/kigya/headway/home/internal/presentation/plugin/HomeStatusPages.kt
+++ b/server/home/internal/src/main/kotlin/dev/kigya/headway/home/internal/presentation/plugin/HomeStatusPages.kt
@@ -1,26 +1,29 @@
 package dev.kigya.headway.home.internal.presentation.plugin
 
+import dev.kigya.headway.common.extension.describeForHttpStatusText
 import dev.kigya.headway.common.extension.handleDefaultExceptions
 import dev.kigya.headway.home.internal.domain.error.HomeException
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.plugins.statuspages.StatusPagesConfig
-import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
 
 internal fun Application.homeStatusPages() {
     install(StatusPages) {
-        handleDefaultExceptions()
         handleHomeExceptions()
+        handleDefaultExceptions()
     }
 }
 
 private fun StatusPagesConfig.handleHomeExceptions() {
     exception<HomeException.InvalidRequest> { call, exception ->
-        call.respond(
+        call.respondText(
+            text = exception.describeForHttpStatusText("Bad request"),
+            contentType = ContentType.Text.Plain,
             status = HttpStatusCode.BadRequest,
-            message = exception.message,
         )
     }
 }


### PR DESCRIPTION
## Summary

This change delivers cross-platform Google and guest sign-in with a shared session domain layer, Apollo GraphQL wiring, and matching gateway and auth service behavior for local and browser clients. It also adds a Render-oriented deployment baseline and tightens error surfaces across a few upstream services.

**Board:** https://github.com/users/kigya/projects/4/views/2

This pull request is **#86** in the repository; use the project board above to attach or advance the matching work item (GitHub does not assign a separate issue number alongside this PR).

## Changes

- **Client (KMP):** Session and auth domain (guest and Google flows), secure storage adapters per platform, Apollo operations and schema, DI modules, auth/home/learn-questions/splash UI and stores, Android/iOS/desktop/web entry points and Google integration glue.
- **Gateway:** Dev CORS for browser GraphQL, upstream error mapping and GraphQL error text alignment, KGraphQL configuration, tests.
- **Auth & data services:** Google ID token verification and configuration, StatusPages plain-text responses, database read paths touched for home and learning flows.
- **Ops:** `render.yaml`, Render Dockerfiles, Android network security config and dev endpoint wiring; assorted agent docs and gitignore hygiene.